### PR TITLE
Replace unittest2 with unittest

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 import tempfile
 import traceback
-import unittest2
+import unittest
 
 from functools import wraps
 from termcolor import cprint
@@ -53,7 +53,7 @@ def main():
     test_class = classes[0]
 
     # create and run the test suite
-    suite = unittest2.TestSuite()
+    suite = unittest.TestSuite()
     for case in config.test_cases:
         suite.addTest(test_class(case))
     results = TestResult()


### PR DESCRIPTION
Per `unittest2`'s [description](https://pypi.python.org/pypi/unittest2), and Python2.7's [documentation](https://docs.python.org/2.7/library/unittest.html):

> unittest2 is a backport of the new features added to the unittest testing framework in Python 2.7 and onwards

Is there a reason `check50` needs to be compatible with pre-2.7 Python (especially since its written in Python 3)?