### PR TITLE
Auto update check50 based on PyPi

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -43,8 +43,7 @@ def main():
 
     # check for newer version on PyPi
     pypi = pypijson.get("check50")
-    pypi_version = StrictVersion(pypi["info"]["version"])
-    if pypi and not args.no_autoupdate and pypi_version > VERSION:
+    if pypi and not args.no_autoupdate and StrictVersion(pypi["info"]["version"]) > VERSION:
 
         # updade check50
         pip = "pip3" if sys.version_info >= (3, 0) else "pip"

--- a/check50.py
+++ b/check50.py
@@ -34,7 +34,7 @@ def main():
     parser.add_argument("-d", "--debug", action="store_true")
     parser.add_argument("-l", "--local", action="store_true")
     parser.add_argument("--log", action="store_true")
-    parser.add_argument("--no-autoupdate", action="store_true")
+    parser.add_argument("--update", action="store_true")
     parser.add_argument("-v", "--verbose", action="store_true")
 
     args = parser.parse_args()
@@ -43,14 +43,14 @@ def main():
 
     # check for newer version on PyPi
     pypi = pypijson.get("check50")
-    if pypi and not args.no_autoupdate and StrictVersion(pypi["info"]["version"]) > VERSION:
+    if pypi and args.update and StrictVersion(pypi["info"]["version"]) > VERSION:
 
         # updade check50
         pip = "pip3" if sys.version_info >= (3, 0) else "pip"
         subprocess.run([pip, "install", "--upgrade", "check50"])
         check50 = os.path.realpath(__file__)
-        os.execv(check50, sys.argv + ["--no-autoupdate"])
-        raise RuntimeError("Impossible.")
+        sys.argv.remove("--update")
+        os.execv(check50, sys.argv)
 
     if not args.local:
         try:

--- a/check50.py
+++ b/check50.py
@@ -21,7 +21,7 @@ import unittest
 
 from distutils.version import StrictVersion
 from functools import wraps
-from pkg_resources import get_distribution, parse_version
+from pkg_resources import DistributionNotFound, get_distribution, parse_version
 from termcolor import cprint
 
 import config

--- a/check50.py
+++ b/check50.py
@@ -34,7 +34,7 @@ def main():
     parser.add_argument("-d", "--debug", action="store_true")
     parser.add_argument("-l", "--local", action="store_true")
     parser.add_argument("--log", action="store_true")
-    parser.add_argument("--update", action="store_true")
+    parser.add_argument("--no-autoupdate", action="store_true")
     parser.add_argument("-v", "--verbose", action="store_true")
 
     args = parser.parse_args()
@@ -43,14 +43,13 @@ def main():
 
     # check for newer version on PyPi
     pypi = pypijson.get("check50")
-    if pypi and args.update and StrictVersion(pypi["info"]["version"]) > VERSION:
+    if pypi and not args.no_autoupdate and StrictVersion(pypi["info"]["version"]) > VERSION:
 
         # updade check50
         pip = "pip3" if sys.version_info >= (3, 0) else "pip"
         subprocess.run([pip, "install", "--upgrade", "check50"])
         check50 = os.path.realpath(__file__)
-        sys.argv.remove("--update")
-        os.execv(check50, sys.argv)
+        os.execv(check50, sys.argv + ["--no-autoupdate"])
 
     if not args.local:
         try:


### PR DESCRIPTION
Resolves #19.

This checks pypi for the latest version of `check50` and compares it against the current version. If a newer version is available, `pip install --upgrade` is run to upgrade the version of `check50`, after which we re-run `check50` (this time passing in the `--no-autoupdate` flag).

The relevant additional code:

```python
    # check for newer version on PyPi
    pypi = pypijson.get("check50")
    if pypi and not args.no_autoupdate and StrictVersion(pypi["info"]["version"]) > VERSION:

        # updade check50
        pip = "pip3" if sys.version_info >= (3, 0) else "pip"
        subprocess.run([pip, "install", "--upgrade", "check50"])
        check50 = os.path.realpath(__file__)
        os.execv(check50, sys.argv + ["--no-autoupdate"])
        raise RuntimeError("Impossible.")
```