### PR TITLE
Remove dependence on pypijson

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -11,6 +11,7 @@ import os
 import pexpect
 import pypijson
 import re
+import requests
 import shlex
 import shutil
 import subprocess
@@ -50,7 +51,8 @@ def main():
     
     # check for newer version on PyPi
     if distribution:
-        pypi = pypijson.get("check50")
+        res = requests.get("https://pypi.python.org/pypi/check50/json")
+        pypi = res.json() if res.status_code == 200 else None
         version = StrictVersion(distribution.version)
         if pypi and not args.no_autoupdate and StrictVersion(pypi["info"]["version"]) > version:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 argparse
 pexpect
+requests
 unittest
 termcolor


### PR DESCRIPTION
Realized in testing `submit50`'s autoupdate this morning that the `pypijson` package (which I used to get the current version of a pypi package) is deprecated and no longer works on some Linux machines. This avoids relying on `pypijson` by making the API call ourselves.