### PR TITLE
Make Child.stdout use pexpect, add valgrind check

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -89,7 +89,7 @@ def main():
                 "print_success": False
             }
             username, commit_hash = submit50.submit("check50", identifier, prompts=prompts)
-            
+
             # Wait until payload comes back with check data.
             print("Running checks...", end="")
             sys.stdout.flush()
@@ -473,7 +473,7 @@ class Checks(unittest.TestCase):
         if sys.version_info < (3, 0):
             child = pexpect.spawn(cmd, echo=False, env=env)
         else:
-            child = pexpect.spawn(cmd, encoding="utf-8", echo=False, env=env)
+            child = pexpect.spawnu(cmd, encoding="utf-8", echo=False, env=env)
         return Child(self, child)
 
     def include(self, path):

--- a/check50.py
+++ b/check50.py
@@ -74,11 +74,12 @@ def main():
     if not args.local:
         try:
             import submit50
+        except ImportError:
+            raise RuntimeError("submit50 is not installed. Install submit50 and run check50 again.")
+        else:
             submit50.run.verbose = args.verbose
             submit50.submit("check50", identifier)
             sys.exit(0)
-        except ImportError:
-            raise RuntimeError("submit50 is not installed. Install submit50 and run check50 again.")
 
     # copy all files to temporary directory
     config.tempdir = tempfile.mkdtemp()
@@ -305,7 +306,10 @@ class Child():
             self.test.log.append("Checking for output \"{}\"...".format(str_output))
 
         if isinstance(output, File):
-            contents = open(output.filename, "r", newline="\r\n").read()
+            if sys.version_info < (3,0):
+                contents = open(output.filename, "rU").read().replace("\n", "\r\n")
+            else:
+                contents = open(output.filename, "r", newline="\r\n").read()
             if str_output is None: str_output = contents
             output = re.escape(contents)
         elif output == EOF:

--- a/checks/cs50/2017/x/greedy/checks.py
+++ b/checks/cs50/2017/x/greedy/checks.py
@@ -3,44 +3,44 @@ import re
 import sys
 
 sys.path.append(os.getcwd())
-from check50 import TestCase, Error, check
+from check50 import *
 
 class Greedy(TestCase):
-    
+
     @check()
     def exists(self):
         """greedy.c exists."""
         super(Greedy, self).exists("greedy.c")
-    
+
     @check("exists")
     def compiles(self):
         """greedy.c compiles."""
-        self.spawn("clang -o greedy greedy.c -lcs50").exit(0)
+        self.spawn("clang -ggdb3 -o greedy greedy.c -lcs50 -lm").exit(0)
 
     @check("compiles")
     def test041(self):
         """input of 0.41 yields output of 4"""
-        self.spawn("./greedy").stdin("0.41").stdout("^4\n$", 4).exit(0)
+        self.spawn("./greedy").stdin("0.41").stdout("^4\n", 4).stdout(EOF).exit(0)
 
     @check("compiles")
     def test001(self):
         """input of 0.01 yields output of 1"""
-        self.spawn("./greedy").stdin("0.01").stdout("^1\n$", 1).exit(0)
+        self.spawn("./greedy").stdin("0.01").stdout("^1\n", 1).stdout(EOF).exit(0)
 
     @check("compiles")
     def test015(self):
         """input of 0.15 yields output of 2"""
-        self.spawn("./greedy").stdin("0.15").stdout("^2\n$", 2).exit(0)
+        self.spawn("./greedy").stdin("0.15").stdout("^2\n", 2).stdout(EOF).exit(0)
 
     @check("compiles")
     def test160(self):
         """input of 1.6 yields output of 7"""
-        self.spawn("./greedy").stdin("1.6").stdout("^7\n$", 7).exit(0)
+        self.spawn("./greedy").stdin("1.6").stdout("^7\n", 7).stdout(EOF).exit(0)
 
     @check("compiles")
     def test230(self):
         """input of 23 yields output of 92"""
-        self.spawn("./greedy").stdin("23").stdout("^92\n$", 92).exit(0)
+        self.spawn("./greedy").stdin("23").stdout("^92\n", 92).stdout(EOF).exit(0)
 
     @check("compiles")
     def test420(self):


### PR DESCRIPTION
Test writers can specify that valgrind should be run on a check by adding the `@valgrind` decorator. The output looks like the following:
```
:) greedy.c exists.                                               
:) greedy.c compiles.                                             
:( input of 0.41 yields output of 4                               
    Valgrind check failed. Rerun with --log for more information. 
:) input of 0.01 yields output of 1                               
...        
```

When run with `--log`, we see the errors valgrind encountered:

```
:) greedy.c exists.
    Checking that greedy.c exists...
:) greedy.c compiles.
    Running clang -ggdb3 -o greedy greedy.c -lcs50 -lm...
    Checking that program exited with status 0...
:( input of 0.41 yields output of 4
    Valgrind check failed. Rerun with --log for more information.
    Running valgrind ./greedy...
    Sending input 0.41...
    Checking for output "4"...
    Checking that program exited with status 0...
    Checking for valgrind errors... 
        Invalid read of size 4: (file: greedy.c, line: 20)
        Conditional jump or move depends on uninitialised value(s): (file: greedy.c, line: 23)
        Use of uninitialised value of size 8: (file: greedy.c, line: 23)
        24 bytes in 1 blocks are definitely lost in loss record 1 of 1: (file: greedy.c, line: 18)
:) input of 0.01 yields output of 1
...
```

This PR also refactors `Child.stdout` to use `pexpect`. Due to how pexpect works, putting the `$` character in regexes no longer does anything. Instead, `.stdout(EOF)` will assert that there is no more output from the process.

Finally, this PR adds a `replace_fn` method to `TestCase` to facilitate replacing function calls in assembly.