### PR TITLE
Skip check on check50 error

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -338,18 +338,17 @@ class TestResult(unittest.TestResult):
         })
 
     def addError(self, test, err):
+        test.log.append(err[1])
+        test.log += traceback.format_tb(err[2])
+        test.log.append("Contact sysadmins@cs50.harvard.edu with the URL of this check!")
         self.results.append({
             "description": test.shortDescription(),
             "helpers": test.helpers,
             "log": test.log,
-            "rationale": err[1],
-            "status": Checks.FAIL,
+            "rationale": "check50 ran into an error while running checks!",
+            "status": Checks.SKIP,
             "test": test
         })
-        cprint("check50 ran into an error while running checks.", "red", file=sys.stderr)
-        print(err[1], file=sys.stderr)
-        traceback.print_tb(err[2])
-        sys.exit(1)
 
 
 def valgrind(func):


### PR DESCRIPTION
So right now, when check50 runs into an error (which has happened a couple times now, usually because of students' code throwing an exception that we don't catch), `unittest` calls the `addError` function.

Currently, `addError` prints out "check50 ran into an error while running checks!" and just terminates the program. But that's not actually all that helpful to the students-- because the checks never finish running and they never get to see the results. So instead, this marks the check for which check50 hit an error as "skipped", and appends to the log details about the exception that was thrown.