### PR TITLE
eof

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -506,6 +506,8 @@ class Child(object):
         try:
             self.child.expect(".+", timeout=timeout)
             self.child.sendline("")
+        except EOF:
+            raise Error("expected prompt for input, found none")
         except OSError:
             self.test.fail()
         except TIMEOUT:

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         "console_scripts": ["check50=check50:main"]
     },
     url="https://github.com/cs50/check50",
-    version="2.0.2"
+    version="2.0.3"
 )


### PR DESCRIPTION
Used to fail when using `--debug` because `EOF` is not serializable. 

```
$ check50 --debug --local cs50/2017/x/mario/less                
Error in sys.excepthook:
Traceback (most recent call last):
  File "/home/kzidane/.virtualenvs/check50/lib/python3.5/shutil.py", line 463, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpkr34mj4l'

Original exception was:
Traceback (most recent call last):
  File "/home/kzidane/.virtualenvs/check50/bin/check50", line 11, in <module>
    load_entry_point('check50', 'console_scripts', 'check50')()
  File "/home/kzidane/github/cs50/check50/check50.py", line 147, in main
    print_json(results)
  File "/home/kzidane/github/cs50/check50/check50.py", line 240, in print_json
    print(json.dumps(output))
  File "/usr/lib/python3.5/json/__init__.py", line 230, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.5/json/encoder.py", line 198, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.5/json/encoder.py", line 256, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.5/json/encoder.py", line 179, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: EOF('End Of File (EOF). Exception style platform.\n<pexpect.pty_spawn.spawn object at 0x7f0248c3f160>\ncommand: /bin/bash\nargs: [b\'/bin/bash\', b\'-c\', b\'./mario\']\nbuffer (last 100 chars): \'\'\nbefore (last 100 chars): \'\'\nafter: <class \'pexpect.exceptions.EOF\'>\nmatch: None\nmatch_index: None\nexitstatus: None\nflag_eof: True\npid: 30533\nchild_fd: 5\nclosed: False\ntimeout: 30\ndelimiter: <class \'pexpect.exceptions.EOF\'>\nlogfile: None\nlogfile_read: None\nlogfile_send: None\nmaxread: 2000\nignorecase: False\nsearchwindowsize: None\ndelaybeforesend: 0.05\ndelayafterclose: 0.1\ndelayafterterminate: 0.1\nsearcher: searcher_re:\n    0: re.compile(".+")',) is not JSON serializable
```