### PR TITLE
Fix replace_fn partial match bug

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -11,6 +11,7 @@ import json
 import os
 import pexpect
 import pip
+import re
 import requests
 import shutil
 import subprocess
@@ -659,8 +660,10 @@ class Checks(unittest.TestCase):
             o.write(code.read())
 
     def replace_fn(self, old_fn, new_fn, filename):
-        self.spawn("sed -i='' -e 's/callq\t_{}/callq\t_{}/g' {}".format(old_fn, new_fn, filename))
-        self.spawn("sed -i='' -e 's/callq\t{}/callq\t{}/g' {}".format(old_fn, new_fn, filename))
+        with open(filename, "r+") as f:
+            asm = re.sub(r"(callq\t_?){}(?!\w)".format(old_fn), r"\1{}".format(new_fn), f.read())
+            f.seek(0)
+            f.write(asm)
 
     def _check_valgrind(self):
         """Log and report any errors encountered by valgrind"""


### PR DESCRIPTION
The previous sed implementation wouldn't just replace e.g. `draw` with `simple_draw`, it would also replace e.g. `drawFoo` with `simple_drawFoo` leading to a compilation failure.

This could be fixed with a more comprehensive `sed` regex, but `sed` has kind of patchy regex support (particularly since we can't guarantee GNU sed), so I just used `re` to do the replacement. It checks to make sure that the character after the matched function is not a `\w` which seems to be sufficient per the [standard](http://crasseux.com/books/ctutorial/Function-names.html).

This should work on Mac (taking into account the prepended `_` in the asm generated by clang), though I can't test this directly.