### PR TITLE
Adds segmentation fault detection, other bugfixes

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -14,6 +14,7 @@ import pip
 import re
 import requests
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -55,7 +56,6 @@ def main():
                         help="run checks completely offline (implies --local)")
     parser.add_argument("--checkdir",
                         action="store",
-                        nargs=1,
                         default="~/.local/share/check50",
                         help="specify directory containing the checks "
                              "(~/.local/share/check50 by default)")
@@ -67,7 +67,7 @@ def main():
                         help="display the full tracebacks of any errors")
 
     config.args = parser.parse_args()
-    config.args.checkdir = os.path.expanduser(config.args.checkdir)
+    config.args.checkdir = os.path.abspath(config.args.checkdir)
     identifier = config.args.identifier[0]
     files = config.args.files
 
@@ -267,7 +267,6 @@ def import_checks(identifier):
     if not config.args.offline:
         if os.path.exists(checks_root):
             command = ["git", "-C", checks_root, "pull", "origin", "master"]
-
         else:
             command = ["git", "clone", "https://github.com/{}/{}".format(org, repo), checks_root]
 
@@ -553,6 +552,10 @@ class Child(object):
 
         self.output = "".join(self.output).replace("\r\n", "\n").lstrip("\n")
         self.kill()
+
+        if self.child.signalstatus == signal.SIGSEGV:
+            raise Error("failed to execute program due to segmentation fault")
+
         self.exitstatus = self.child.exitstatus
         return self
 


### PR DESCRIPTION
It was reported that `check50` was incorrectly passing a student's find implementation since their program segfaulted when trying to find an element that didn't exist. Programs return 1 when they segfault, so it looked like the correct behavior. This PR alters the `Child.wait` method to check if the child was signaled with a `SIGSEGV` and raises an `Error` if it was.

It also fixes the bug where `checksdir` was being saved as a list and it wasn't expanding relative paths e.g. ".."