### PR TITLE
Fix non-utf8 bug in python2

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import argparse
 import errno
@@ -247,6 +248,7 @@ def print_json(results):
             pass
 
         output.append(obj)
+
     print(json.dumps(output, cls=Encoder))
 
 
@@ -772,10 +774,7 @@ class Checks(unittest.TestCase):
         # Workaround for OSX pexpect bug http://pexpect.readthedocs.io/en/stable/commonissues.html#truncated-output-just-before-child-exits
         # Workaround from https://github.com/pexpect/pexpect/issues/373
         cmd = "bash -c {}".format(quote(cmd))
-        if sys.version_info < (3, 0):
-            child = pexpect.spawn(cmd, echo=False, env=env)
-        else:
-            child = pexpect.spawnu(cmd, encoding="utf-8", echo=False, env=env)
+        child = pexpect.spawn(cmd, echo=False, encoding="utf-8", env=env)
 
         self.children.append(Child(self, child))
         return self.children[-1]

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
         "console_scripts": ["check50=check50:main"]
     },
     url="https://github.com/cs50/check50",
-    version="2.2.2"
+    version="2.2.3"
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "Topic :: Utilities"
     ],
     description="This is check50, with which you can check solutions to problems for CS50.",
-    install_requires=["argparse", "bs4", "pexpect", "requests", "backports.shutil_which", "six", "termcolor", "submit50>=2.4.5"],
+    install_requires=["argparse", "bs4", "pexpect>=4.0", "requests", "backports.shutil_which", "six", "termcolor", "submit50>=2.4.5"],
     keywords=["check", "check50"],
     name="check50",
     py_modules=["check50", "config"],


### PR DESCRIPTION
Resolves: #94 

This fix seems to work in my testing. Anyone see any potential issues with this?

This PR uses `pexpect.spawn` regardless of python version since `pexpect` merged `spawn` and `spawnu` in v4.0. Unfortunately in `python2` this means that `pexpect.spawn.expect` would expect a unicode literal (e.g. `u"hello"`), which we address by making these the default (as is the case in python3) via a `__future__` import.

This is addressed implicitly in the next version of `check50` (in `check50api-pool`) since it requires Python 3.6. 