### PR TITLE
add sanity checks to register

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -29,10 +29,6 @@ from .runner import CheckRunner, CheckResult
 lib50.api.LOCAL_PATH = "~/.local/share/check50"
 
 
-class Error(Exception):
-    pass
-
-
 def excepthook(cls, exc, tb):
     if excepthook.output == "json":
         json.dump({
@@ -44,7 +40,7 @@ def excepthook(cls, exc, tb):
         }, sys.stdout, indent=4)
         print()
     else:
-        if (issubclass(cls, Error) or issubclass(cls, lib50.Error)) and exc.args:
+        if (issubclass(cls, internal.Error) or issubclass(cls, lib50.Error)) and exc.args:
             cprint(str(exc), "red", file=sys.stderr)
         elif issubclass(cls, FileNotFoundError):
             cprint(_("{} not found").format(exc.filename), "red", file=sys.stderr)
@@ -121,7 +117,7 @@ def install_dependencies(dependencies, verbose=False):
         try:
             subprocess.check_call(pip, stdout=stdout, stderr=stderr)
         except subprocess.CalledProcessError:
-            raise Error(_("failed to install dependencies"))
+            raise internal.Error(_("failed to install dependencies"))
 
 
 def install_translations(config):
@@ -157,7 +153,7 @@ def await_results(url, pings=45, sleep=2):
     else:
         # Terminate if no response
         print()
-        raise Error(
+        raise internal.Error(
             _("check50 is taking longer than normal!\nSee https://cs50.me/checks/{} for more detail.").format(commit_hash))
     print()
 
@@ -176,7 +172,7 @@ class LogoutAction(argparse.Action):
         try:
             lib50.logout()
         except lib50.Error:
-            raise Error(_("failed to logout"))
+            raise internal.Error(_("failed to logout"))
         else:
             termcolor.cprint(_("logged out successfully"), "green")
         parser.exit()
@@ -238,7 +234,7 @@ def main():
         if args.dev:
             internal.check_dir = Path(args.slug).expanduser().resolve()
             if not internal.check_dir.is_dir():
-                raise Error(_("{} is not a directory").format(internal.check_dir))
+                raise internal.Error(_("{} is not a directory").format(internal.check_dir))
         else:
             # Otherwise have lib50 create a local copy of slug
             internal.check_dir = lib50.local(args.slug, "check50", offline=args.offline)

--- a/check50/internal.py
+++ b/check50/internal.py
@@ -31,8 +31,16 @@ class Register:
     :data:`check50.internal.register` should be the sole instance of this class.
     """
     def __init__(self):
-        self._before_everies = []
-        self._after_everies = []
+        def _running_callback():
+            global check_running
+            check_running = True
+
+        def _not_running_callback():
+            global check_running
+            check_running = False
+
+        self._before_everies = [_running_callback]
+        self._after_everies = [_not_running_callback]
         self._after_checks = []
 
     def after_check(self, func):

--- a/check50/internal.py
+++ b/check50/internal.py
@@ -31,16 +31,8 @@ class Register:
     :data:`check50.internal.register` should be the sole instance of this class.
     """
     def __init__(self):
-        def _running_callback():
-            global check_running
-            check_running = True
-
-        def _not_running_callback():
-            global check_running
-            check_running = False
-
-        self._before_everies = [_running_callback]
-        self._after_everies = [_not_running_callback]
+        self._before_everies = []
+        self._after_everies = []
         self._after_checks = []
 
     def after_check(self, func):

--- a/check50/internal.py
+++ b/check50/internal.py
@@ -16,6 +16,14 @@ check_dir = None
 #: Temporary directory in which check is being run
 run_dir = None
 
+#: Boolean that indicates if a check is currently running
+check_running = False
+
+
+class Error(Exception):
+    """Exception for internal check50 errors."""
+    pass
+
 
 class Register:
     """
@@ -28,15 +36,31 @@ class Register:
         self._after_checks = []
 
     def after_check(self, func):
-        """Run func once at the end of the check, then discard func."""
+        """Run func once at the end of the check, then discard func.
+
+        :param func: callback to run after check
+        :raises check50.internal.Error: if called when no check is being run"""
+        if not check_running:
+            raise Error("cannot register callback to run after check when no check is running")
         self._after_checks.append(func)
 
     def after_every(self, func):
-        """Run func at the end of every check."""
+        """Run func at the end of every check.
+
+        :param func: callback to be run after every check
+        :raises check50.internal.Error: if called when a check is being run"""
+        if check_running:
+            raise Error("cannot register callback to run after every check when check is running")
         self._after_everies.append(func)
 
     def before_every(self, func):
-        """Run func at the start of every check."""
+        """Run func at the start of every check.
+
+        :param func: callback to be run before every check
+        :raises check50.internal.Error: if called when a check is being run"""
+
+        if check_running:
+            raise Error("cannot register callback to run before every check when check is running")
         self._before_everies.append(func)
 
     def __enter__(self):

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -93,17 +93,17 @@ def check(dependency=None, timeout=60):
 
         @check50.check() # Mark 'exists' as a check
         def exists():
-            \"""hello.c exists\"""
+            \"\"\"hello.c exists\"\"\"
             check50.exists("hello.c")
 
         @check50.check(exists) # Mark 'compiles' as a check that depends on 'exists'
         def compiles():
-            \"""hello.c compiles\"""
+            \"\"\"hello.c compiles\"\"\"
             check50.c.compile("hello.c")
 
         @check50.check(compiles)
         def prints_hello():
-            \"""prints "Hello, world!\\\\n\"""
+            \"\"\"prints "Hello, world!\\\\n\"\"\"
             # Since 'prints_hello', depends on 'compiles' it inherits the compiled binary
             check50.run("./hello").stdout("[Hh]ello, world!?\\n", "hello, world\\n").exit()
 
@@ -240,9 +240,4 @@ class run_check:
     def __call__(self):
         mod = importlib.util.module_from_spec(self.spec)
         self.spec.loader.exec_module(mod)
-        internal.check_running = True
-        try:
-            return getattr(mod, self.check_name)(self.checks_root, self.state)
-        finally:
-            internal.check_running = False
-
+        return getattr(mod, self.check_name)(self.checks_root, self.state)

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -93,17 +93,17 @@ def check(dependency=None, timeout=60):
 
         @check50.check() # Mark 'exists' as a check
         def exists():
-            \"\"\"hello.c exists\"\"\"
+            \"""hello.c exists\"""
             check50.exists("hello.c")
 
         @check50.check(exists) # Mark 'compiles' as a check that depends on 'exists'
         def compiles():
-            \"\"\"hello.c compiles\"\"\"
+            \"""hello.c compiles\"""
             check50.c.compile("hello.c")
 
         @check50.check(compiles)
         def prints_hello():
-            \"\"\"prints "Hello, world!\\\\n\"\"\"
+            \"""prints "Hello, world!\\\\n\"""
             # Since 'prints_hello', depends on 'compiles' it inherits the compiled binary
             check50.run("./hello").stdout("[Hh]ello, world!?\\n", "hello, world\\n").exit()
 
@@ -240,4 +240,9 @@ class run_check:
     def __call__(self):
         mod = importlib.util.module_from_spec(self.spec)
         self.spec.loader.exec_module(mod)
-        return getattr(mod, self.check_name)(self.checks_root, self.state)
+        internal.check_running = True
+        try:
+            return getattr(mod, self.check_name)(self.checks_root, self.state)
+        finally:
+            internal.check_running = False
+

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -240,4 +240,9 @@ class run_check:
     def __call__(self):
         mod = importlib.util.module_from_spec(self.spec)
         self.spec.loader.exec_module(mod)
-        return getattr(mod, self.check_name)(self.checks_root, self.state)
+        internal.check_running = True
+        try:
+            return getattr(mod, self.check_name)(self.checks_root, self.state)
+        finally:
+            internal.check_running = False
+

--- a/tests/c_tests.py
+++ b/tests/c_tests.py
@@ -53,6 +53,7 @@ class TestValgrind(Base):
             f.write(src)
 
         check50.c.compile("foo.c")
+        check50.internal.check_running = True
         with check50.internal.register:
             check50.c.valgrind("./foo").exit()
 
@@ -66,6 +67,7 @@ class TestValgrind(Base):
             f.write(src)
 
         check50.c.compile("leak.c")
+        check50.internal.check_running = True
         with self.assertRaises(check50.Failure):
             with check50.internal.register:
                 check50.c.valgrind("./leak").exit()

--- a/tests/c_tests.py
+++ b/tests/c_tests.py
@@ -46,6 +46,11 @@ class TestValgrind(Base):
         super().setUp()
         if not (sys.platform == "linux" or sys.platform == "linux2"):
             raise unittest.SkipTest("skipping valgrind checks under anything other than Linux due to false positives")
+        check50.internal.check_running = False
+
+    def tearDown(self):
+        super().tearDown()
+        check50.internal.check_running = False
 
     def test_no_leak(self):
         with open("foo.c", "w") as f:

--- a/tests/internal_tests.py
+++ b/tests/internal_tests.py
@@ -3,8 +3,15 @@ import check50
 import check50.internal
 
 class TestRegisterAfterCheck(unittest.TestCase):
+    def tearDown(self):
+        check50.internal.check_running = False
+
     def test_after_check(self):
         l = []
+        with self.assertRaises(check50.internal.Error):
+            check50.internal.register.after_check(lambda : l.append("qux"))
+
+        check50.internal.check_running = True
         check50.internal.register.after_check(lambda : l.append("foo"))
 
         with check50.internal.register:

--- a/tests/internal_tests.py
+++ b/tests/internal_tests.py
@@ -3,6 +3,9 @@ import check50
 import check50.internal
 
 class TestRegisterAfterCheck(unittest.TestCase):
+    def setUp(self):
+        check50.internal.check_running = False
+
     def tearDown(self):
         check50.internal.check_running = False
 


### PR DESCRIPTION
It occurred to me when writing the `Challenges` section, that weird things could happen if you called `after_check` when no check is being run or `{before,after}_every` when one is. This PR adds sanity checks to prevent that.