### PR TITLE
Wording tweak for valgrind

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -834,7 +834,7 @@ class Checks(unittest.TestCase):
 
         # Only raise exception if we encountered errors.
         if reported:
-            raise Error("valgrind tests failed; rerun with --log for more information.")
+            raise Error("valgrind tests failed; rerun check50 with --log added to end of command for more information.")
 
 
 class Mismatch(object):


### PR DESCRIPTION
Caroline mentioned that a student was having trouble understanding what `rerun with --log` meant in the case of `valgrind` checks failing, so maybe a wording tweak would be useful to be a little more descriptive as to how to use it?