### PR TITLE
Fix multiple dependencies not installing

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -114,7 +114,8 @@ def install_dependencies(dependencies, verbose=False):
         req_file = Path(req_dir) / "requirements.txt"
 
         with open(req_file, "w") as f:
-            f.writelines(dependencies)
+            for dependency in dependencies:
+                f.write(f"{dependency}\n")
 
         pip = ["pip", "install", "-r", req_file]
         # Unless we are in a virtualenv, we need --user


### PR DESCRIPTION
Turns out `.writelines` does not insert newlines. This caused `check50` to try and install things like `numpyjupyter` instead of `numpy` and `jupyter`.

Simple test:
```
check50 jelleas/check50_dependencies/master -v
```