### PR TITLE
use subprocess to call pip instead of the removed pip.main() interface

### DIFF
--- a/check50.py
+++ b/check50.py
@@ -309,7 +309,7 @@ def import_checks(identifier):
                 args += ["--quiet"] * 3
 
             try:
-                code = __import__("pip").main(args)
+                code = subprocess.call([sys.executable, "-m", "pip", *args])
             except SystemExit as e:
                 code = e.code
 

--- a/check50.py
+++ b/check50.py
@@ -309,11 +309,8 @@ def import_checks(identifier):
                 args += ["--quiet"] * 3
 
             try:
-                code = subprocess.call([sys.executable, "-m", "pip", *args])
-            except SystemExit as e:
-                code = e.code
-
-            if code:
+                subprocess.check_call([sys.executable, "-m", "pip"] + args)
+            except subprocess.CalledProcessError:
                 raise InternalError("failed to install dependencies in ({})".format(
                     requirements[len(config.args.checkdir) + 1:]))
 

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
         "console_scripts": ["check50=check50:main"]
     },
     url="https://github.com/cs50/check50",
-    version="2.2.5"
+    version="2.2.6"
 )


### PR DESCRIPTION
**tl;dr** - fix for failing finance checks. My students will be using next week, so if at all possible, I would appreciate a deploy 😬

It seems that in the IDE at ide.legacy.cs50.io, the checks for Finance aren't working anymore. These checks depend on an install via a `requirements.txt`. Apparently the recent version of `pip` that is now available in the IDE is the root cause of this failure.

`check50` currently uses the `main()` method from the pip module. However, this has been removed a couple of versions ago, [according to this](https://stackoverflow.com/questions/12332975/installing-python-module-within-code/50255019#50255019).

In this PR, I've replaced that call with the use of the `subprocess` module, which was already imported anyway. I have tested this change in the IDE, with the Finance checks, and they once again work. I have not tested this change with any other checks.

Obv this needs to be deployed to the IDE to be of any use :-)