### PR TITLE
v3.0.8

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -366,6 +366,7 @@ def main():
                     }
 
 
+    breakpoint()
     # Render output
     file_manager = open(args.output_file, "w") if args.output_file else nullcontext(sys.stdout)
     with file_manager as output_file:

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -79,7 +79,7 @@ def excepthook(cls, exc, tb):
             if excepthook.verbose:
                 traceback.print_exception(cls, exc, tb)
                 if hasattr(exc, "payload"):
-                    print("Exception payload:", exc.payload)
+                    print("Exception payload:", json.dumps(exc.payload), sep="\n")
 
     sys.exit(1)
 
@@ -366,7 +366,6 @@ def main():
                     }
 
 
-    breakpoint()
     # Render output
     file_manager = open(args.output_file, "w") if args.output_file else nullcontext(sys.stdout)
     with file_manager as output_file:

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -263,7 +263,7 @@ class run:
                 result += self.process.after
             raise Mismatch(str_output, result.replace("\r\n", "\n"))
         except TIMEOUT:
-            raise Failure(_("did not find \"{}\"").format(_raw(str_output)))
+            raise Failure(_("did not find {}").format(_raw(str_output)))
         except UnicodeDecodeError:
             raise Failure(_("output not valid ASCII text"))
         except Exception:
@@ -402,7 +402,14 @@ class Mismatch(Failure):
     """
 
     def __init__(self, expected, actual, help=None):
-        super().__init__(rationale=_("expected \"{}\", not \"{}\"").format(_raw(expected), _raw(actual)), help=help)
+        super().__init__(rationale=_("expected {}, not {}").format(_raw(expected), _raw(actual)), help=help)
+
+        if expected == EOF:
+            expected = "EOF"
+
+        if actual == EOF:
+            actual = "EOF"
+
         self.payload.update({"expected": expected, "actual": actual})
 
 
@@ -445,8 +452,7 @@ def _raw(s):
     if s == EOF:
         return "EOF"
 
-    s = repr(s)  # Get raw representation of string
-    s = s[1:-1]  # Strip away quotation marks
+    s = f'"{repr(s)[1:-1]}"'
     if len(s) > 15:
         s = s[:15] + "..."  # Truncate if too long
     return s

--- a/check50/_simple.py
+++ b/check50/_simple.py
@@ -22,16 +22,16 @@ def _run(arg):
 
 def _stdin(arg):
     if isinstance(arg, list):
-        arg = r"\n".join(arg)
+        arg = r"\n".join(str(a) for a in arg)
 
-    arg = arg.replace("\n", r"\n").replace("\t", r"\t").replace('"', '\"')
+    arg = str(arg).replace("\n", r"\n").replace("\t", r"\t").replace('"', '\"')
     return f'.stdin("{arg}", prompt=False)'
 
 
 def _stdout(arg):
     if isinstance(arg, list):
-        arg = r"\n".join(arg)
-    arg = arg.replace("\n", r"\n").replace("\t", r"\t").replace('"', '\"')
+        arg = r"\n".join(str(a) for a in arg)
+    arg = str(arg).replace("\n", r"\n").replace("\t", r"\t").replace('"', '\"')
     return f'.stdout("{arg}", regex=False)'
 
 

--- a/check50/renderer/_renderers.py
+++ b/check50/renderer/_renderers.py
@@ -1,27 +1,11 @@
 import json
 import pathlib
 
-import attr
 import jinja2
 import pkg_resources
-from pexpect.exceptions import EOF
 import termcolor
 
-from ..runner import CheckResult
-
 TEMPLATES = pathlib.Path(pkg_resources.resource_filename("check50.renderer", "templates"))
-
-
-class Encoder(json.JSONEncoder):
-    """Custom class for JSON encoding."""
-
-    def default(self, o):
-        if o == EOF:
-            return "EOF"
-        elif isinstance(o, CheckResult):
-            return attr.asdict(o)
-        else:
-            return o.__dict__
 
 
 def to_html(slug, results, version):

--- a/check50/renderer/_renderers.py
+++ b/check50/renderer/_renderers.py
@@ -12,6 +12,18 @@ from ..runner import CheckResult
 TEMPLATES = pathlib.Path(pkg_resources.resource_filename("check50.renderer", "templates"))
 
 
+class Encoder(json.JSONEncoder):
+    """Custom class for JSON encoding."""
+
+    def default(self, o):
+        if o == EOF:
+            return "EOF"
+        elif isinstance(o, CheckResult):
+            return attr.asdict(o)
+        else:
+            return o.__dict__
+
+
 def to_html(slug, results, version):
     with open(TEMPLATES / "results.html") as f:
         content = f.read()

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.0.8",
+    version="3.0.9",
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.0.7",
+    version="3.0.8",
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.0.9",
+    version="3.0.8",
     include_package_data=True
 )


### PR DESCRIPTION
Saw that someone was running into this issue in front. Previously this would throw an error:

```
check:
  run: ./foo
  stdin: 3.2
  stdout: 4
```