### PR TITLE
Small changes to allow using check50 to test programs with very large input

### DIFF
--- a/check50/_api.py
+++ b/check50/_api.py
@@ -163,12 +163,15 @@ class run:
         command = "bash -c {}".format(shlex.quote(command))
         self.process = pexpect.spawn(command, encoding="utf-8", echo=False, env=full_env)
 
-    def stdin(self, line, prompt=True, timeout=3):
+    def stdin(self, line, str_line=None, prompt=True, timeout=3):
         """
         Send line to stdin, optionally expect a prompt.
 
         :param line: line to be send to stdin
         :type line: str
+        :param str_line: what will be displayed as the delivered input, a human \
+                           readable form of ``line``
+        :type str_line: str
         :param prompt: boolean indicating whether a prompt is expected, if True absorbs \
                        all of stdout before inserting line into stdin and raises \
                        :class:`check50.Failure` if stdout is empty
@@ -178,10 +181,13 @@ class run:
         :raises check50.Failure: if ``prompt`` is set to True and no prompt is given
 
         """
+        if str_line is None:
+            str_line = line
+
         if line == EOF:
             log("sending EOF...")
         else:
-            log(_("sending input {}...").format(line))
+            log(_("sending input {}...").format(str_line))
 
         if prompt:
             try:
@@ -263,7 +269,7 @@ class run:
                 result += self.process.after
             raise Mismatch(str_output, result.replace("\r\n", "\n"))
         except TIMEOUT:
-            raise Failure(_("did not find {}").format(_raw(str_output)))
+            raise Failure(_("did not find {} within {} seconds").format(_raw(str_output), timeout))
         except UnicodeDecodeError:
             raise Failure(_("output not valid ASCII text"))
         except Exception:

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -274,7 +274,7 @@ class run:
         except TIMEOUT:
             if show_timeout:
                 raise Missing(str_output, self.process.before,
-                              help=_("check50 waited {} seconds for the output of your program").format(timeout))
+                              help=_("check50 waited {} seconds for the output of the program").format(timeout))
             raise Missing(str_output, self.process.before)
         except UnicodeDecodeError:
             raise Failure(_("output not valid ASCII text"))

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -213,7 +213,7 @@ class run:
             pass
         return self
 
-    def stdout(self, output=None, str_output=None, regex=True, timeout=3):
+    def stdout(self, output=None, str_output=None, regex=True, timeout=3, show_timeout=False):
         """
         Retrieve all output from stdout until timeout (3 sec by default). If ``output``
         is None, ``stdout`` returns all of the stdout outputted by the process, else
@@ -229,6 +229,9 @@ class run:
         :type regex: bool
         :param timeout: maximum number of seconds to wait for ``output``
         :type timeout: int / float
+        :param show_timeout: flag indicating whether the timeout in seconds \
+                                  should be displayed when a timeout occurs
+        :type show_timeout: bool
         :raises check50.Mismatch: if ``output`` is specified and nothing that the \
                                   process outputs matches it
         :raises check50.Failure: if process times out or if it outputs invalid UTF-8 text.
@@ -269,7 +272,9 @@ class run:
                 result += self.process.after
             raise Mismatch(str_output, result.replace("\r\n", "\n"))
         except TIMEOUT:
-            raise Failure(_("did not find {} within {} seconds").format(_raw(str_output), timeout))
+            if show_timeout:
+                raise Failure(_("did not find {} within {} seconds").format(_raw(str_output), timeout))
+            raise Failure(_("did not find {}").format(_raw(str_output)))
         except UnicodeDecodeError:
             raise Failure(_("output not valid ASCII text"))
         except Exception:

--- a/tests/check50_tests.py
+++ b/tests/check50_tests.py
@@ -102,6 +102,17 @@ class TestStdoutPy(Base):
         process.expect_exact("prints hello")
         process.close(force=True)
 
+class TestStdoutTimeout(Base):
+    def test_stdout_timeout(self):
+        with open("foo.py", "w") as f:
+            f.write("while True: pass")
+
+        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdout_py")
+        process.expect_exact(":)")
+        process.expect_exact("foo.py exists")
+        process.expect_exact(":(")
+        process.expect_exact("did not find \"hello\" within 3 seconds")
+        process.close(force=True)
 
 class TestStdinPy(Base):
     def test_no_file(self):
@@ -228,6 +239,36 @@ class TestStdinMultiline(Base):
         process.expect_exact("prints hello name (chaining)")
         process.expect_exact(":)")
         process.expect_exact("prints hello name (chaining) (order)")
+        process.close(force=True)
+
+class TestStdinHumanReadable(Base):
+    def test_without_human_readable_string(self):
+        with open("foo.py", "w") as f:
+            f.write('name = input()\nprint("hello", name)')
+
+        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_py")
+        process.expect_exact(":)")
+        process.expect_exact("foo.py exists")
+        process.expect_exact("checking that foo.py exists...")
+        process.expect_exact(":)")
+        process.expect_exact("prints hello name")
+        process.expect_exact("running python3 foo.py...")
+        process.expect_exact("sending input bar...")
+        process.expect_exact("checking for output \"hello bar\"...")
+        process.close(force=True)
+
+    def test_with_human_readable_string(self):
+        with open("foo.py", "w") as f:
+            f.write('name = input("prompt")')
+
+        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_human_readable_py")
+        process.expect_exact(":)")
+        process.expect_exact("foo.py exists")
+        process.expect_exact("checking that foo.py exists...")
+        process.expect_exact(":)")
+        process.expect_exact("takes input")
+        process.expect_exact("running python3 foo.py...")
+        process.expect_exact("sending input bbb...")
         process.close(force=True)
 
 

--- a/tests/check50_tests.py
+++ b/tests/check50_tests.py
@@ -111,7 +111,7 @@ class TestStdoutTimeout(Base):
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact(":(")
-        process.expect_exact("did not find \"hello\" within 3 seconds")
+        process.expect_exact("check50 waited 1 seconds for the output of the program")
         process.close(force=True)
 
 class TestStdinPy(Base):

--- a/tests/checks/stdin_human_readable_py/.cs50.yaml
+++ b/tests/checks/stdin_human_readable_py/.cs50.yaml
@@ -1,0 +1,2 @@
+check50:
+  checks: check.py

--- a/tests/checks/stdin_human_readable_py/check.py
+++ b/tests/checks/stdin_human_readable_py/check.py
@@ -1,0 +1,11 @@
+import check50
+
+@check50.check()
+def exists():
+    """foo.py exists"""
+    check50.exists("foo.py")
+
+@check50.check(exists)
+def takes_input():
+    """takes input"""
+    check50.run("python3 foo.py").stdin("aaa", prompt=False, str_line="bbb")

--- a/tests/checks/stdout_py/check.py
+++ b/tests/checks/stdout_py/check.py
@@ -8,4 +8,4 @@ def exists():
 @check50.check(exists)
 def prints_hello():
     """prints hello"""
-    check50.run("python3 foo.py").stdout("hello")
+    check50.run("python3 foo.py").stdout("hello", show_timeout=True, timeout=1)


### PR DESCRIPTION
This commit makes the following two changes:

* The error message displayed by `check.stdout` on timeout now displays a message reflecting that a timeout was the cause of the failed check.
* `check.stdin` now has an optional parameter for a human-readable string, shown to the user as part of the check, instead of the actual string supplied. `check.stdout` already had such a parameter.

Additionally, this commit adds two unit tests to the collection of tests to ensure that these changes work as expected.

These two changes are made to allow the following two use cases:

1. (My current use case) We want to test whether a sorting function was implemented in O(n * log(n)) or in O(n^2). Experimentation suggests that any reasonable implementation of an O(n * log(n)) sorting algorithm in C will take less than a second to sort 500,000 integers. On the other hand, no ordinary implementation of an O(n^2) (average-case) sorting algorithm will sort 500,000 integers within 10 seconds. This means we can test the distinction using check50. This requires us to supply enormous inputs to the function. If these are displayed to the user, as `check.stdin` does before this commit, the checks become unusable. Furthermore, if the error for the time-out does not tell the user that it is *because* of the time-out, they cannot learn from the error.
2. (My upcoming use case) In some cases we may want to send human-unreadable input to a program, e.g. [a graph represented as a series of numbers](https://open.kattis.com/problems/shortestpath1). In such a situation, it can be much more useful to supply a human-readable description of the graph, such as "complete graph on 10 vertices" or "a cycle with 100 edges" rather than a series of numbers.