### PR TITLE
Show program output + monospace logs in webview

### DIFF
--- a/check50/internal.py
+++ b/check50/internal.py
@@ -178,6 +178,7 @@ def import_file(name, path):
     spec.loader.exec_module(mod)
     return mod
 
+
 def _yes_no_prompt(prompt):
     """
     Raise a prompt, returns True if yes is entered, False if no is entered.

--- a/check50/renderer/templates/results.html
+++ b/check50/renderer/templates/results.html
@@ -24,6 +24,8 @@
                       <div class="well well-sm">
                           {# Reason why the check received its status #}
                           {% if check.cause %}
+                          <p>
+                              <b>Cause</b><br/>
                               {% autoescape false %}
                                   {{ check.cause.rationale | e | replace(" ", "&nbsp;") }}
                               {% endautoescape %}
@@ -34,16 +36,20 @@
                                       <br/>
                                   {% endif %}
                               {% endautoescape %}
+                          </p>
                           {% endif %}
 
                           {# Log information #}
                           {% if check.log %}
-                              <b>Log</b>
-                              <br/>
-                              {% for item in check.log %}
-                                  {{ item }}
-                                  <br/>
-                              {% endfor %}
+                              <samp>
+                                  <b>Log</b><br/>
+                                  <div style="border:2px solid; padding:2px;">
+                                      {% for item in check.log %}
+                                          {{ item }}
+                                          <br/>
+                                      {% endfor %}
+                                  </div>
+                              </samp>
                           {% endif %}
 
                           {% if check.cause and check.cause.error %}
@@ -97,6 +103,38 @@
                                                   {% set actual = check.cause.actual | e %}
                                               {% endif %}
                                               {{ actual | replace(" ", "&nbsp;") | replace("\n", "<br/>") }}
+                                          {% endautoescape %}
+                                      </samp>
+                                      </div>
+                                  </div>
+                              </div>
+                          {% endif %}
+
+                          {# Missing if there was one #}
+                          {% if check.cause and "missing_item" in check.cause and "collection" in check.cause %}
+                              <br/>
+
+                              <div class="row">
+                                  <div class="col-md-6">
+                                      <b>Could not find the following in the output:</b>
+                                      <br/>
+                                      <div style="background-color:black; color:#90ee90;">
+                                      <samp>
+                                          {% autoescape false %}
+                                              {% set item = check.cause.missing_item | e %}
+                                              {{ item | replace(" ", "&nbsp;") | replace("\n", "<br/>") }}
+                                          {% endautoescape %}
+                                      </samp>
+                                      </div>
+                                  </div>
+                                  <div class="col-md-6">
+                                      <b>Actual Output:</b>
+                                      <br/>
+                                      <div style="background-color:black; color:white;">
+                                      <samp>
+                                          {% autoescape false %}
+                                              {% set collection = check.cause.collection | e %}
+                                              {{ collection | replace(" ", "&nbsp;") | replace("\n", "<br/>") }}
                                           {% endautoescape %}
                                       </samp>
                                       </div>


### PR DESCRIPTION
Introducing `check50.Missing`. A custom Failure for when check50 is looking for an item, but it can't find it. 

The use case here is primarily the occurrence of a timeout in `.stdout()`. In which case check50 would've failed to find some string/regex in stdout. Currently check50 raises a generic Failure here, but that would truncate the expected output (other than in the log), as it needs to fit in a small terminal, and not show the output of the program up to that point. See example below:

![image](https://user-images.githubusercontent.com/1257775/77317108-df334080-6d0a-11ea-93b7-02ff7343760a.png)

`check50.Missing` addresses this and generates the below:

![image](https://user-images.githubusercontent.com/1257775/77317429-74363980-6d0b-11ea-8703-899b2ce53351.png)

I've also taken the liberty of introducing a monospace font in the logs (through `<samp>`). As more often than not, there is some form of code/output in the logs that would otherwise be hard to read.



  