### PR TITLE
use sys.executable instead of python3 to pip install

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -119,7 +119,7 @@ def install_dependencies(dependencies, verbose=False):
             for dependency in dependencies:
                 f.write(f"{dependency}\n")
 
-        pip = [sys.executable, "-m", "pip", "install", "-r", req_file]
+        pip = [sys.executable or "python3", "-m", "pip", "install", "-r", req_file]
         # Unless we are in a virtualenv, we need --user
         if sys.base_prefix == sys.prefix and not hasattr(sys, "real_prefix"):
             pip.append("--user")

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -119,7 +119,7 @@ def install_dependencies(dependencies, verbose=False):
             for dependency in dependencies:
                 f.write(f"{dependency}\n")
 
-        pip = ["python3", "-m", "pip", "install", "-r", req_file]
+        pip = [sys.executable, "-m", "pip", "install", "-r", req_file]
         # Unless we are in a virtualenv, we need --user
         if sys.base_prefix == sys.prefix and not hasattr(sys, "real_prefix"):
             pip.append("--user")


### PR DESCRIPTION
Ran into this on a machine with two versions of Python installed. check50 was installed on a newer version of Python, whereas python3 referred to the older version.