### PR TITLE
V3.1.0: verbosity levels, logging, --no-install-dependencies

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -212,7 +212,7 @@ class LogoutAction(argparse.Action):
         except lib50.Error:
             raise internal.Error(_("failed to logout"))
         else:
-            termcolor.termcolor.cprint(_("logged out successfully"), "green")
+            termcolor.cprint(_("logged out successfully"), "green")
         parser.exit()
 
 

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -159,6 +159,31 @@ def compile_checks(checks, prompt=False):
     return "__init__.py"
 
 
+def setup_logging(level):
+    """
+    Sets up logging for lib50.
+    level 'info' logs all git commands run to stderr
+    level 'debug' logs all git commands and their output to stderr
+    """
+    # No verbosity level set, don't log anything
+    if not level:
+        return
+
+    # Set verbosity level on the lib50 logger
+    lib50_logger = logging.getLogger("lib50")
+    if level == "debug":
+        lib50_logger.setLevel(logging.DEBUG)
+    elif level == "info":
+        lib50_logger.setLevel(logging.INFO)
+    else:
+        raise ValueError(f'Unknown logging level: "{level}"')
+
+    # Direct all logs to sys.stderr
+    lib50_logger.addHandler(logging.StreamHandler(sys.stderr))
+
+    # Don't animate the progressbar
+    lib50.ProgressBar.DISABLED = True
+
 
 def await_results(commit_hash, slug, pings=45, sleep=2):
     """
@@ -183,13 +208,11 @@ def await_results(commit_hash, slug, pings=45, sleep=2):
             _("check50 is taking longer than normal!\n"
               "See https://submit.cs50.io/check50/{} for more detail").format(commit_hash))
 
-
     if not results["check50"]:
         raise RemoteCheckError(results)
 
     if "error" in results["check50"]:
         raise RemoteCheckError(results["check50"])
-
 
     # TODO: Should probably check payload["version"] here to make sure major version is same as __version__
     # (otherwise we may not be able to parse results)
@@ -240,7 +263,7 @@ def main():
     parser.add_argument("slug", help=_("prescribed identifier of work to check"))
     parser.add_argument("-d", "--dev",
                         action="store_true",
-                        help=_("run check50 in development mode (implies --offline and --verbose).\n"
+                        help=_("run check50 in development mode (implies --offline and --verbose info).\n"
                                "causes SLUG to be interpreted as a literal path to a checks package"))
     parser.add_argument("--offline",
                         action="store_true",
@@ -266,8 +289,14 @@ def main():
                         metavar="FILE",
                         help=_("file to write output to"))
     parser.add_argument("-v", "--verbose",
-                        action="store_true",
-                        help=_("display the full tracebacks of any errors (also implies --log)"))
+                        action="store",
+                        nargs="?",
+                        default="",
+                        const="info",
+                        choices=["info", "debug"],
+                        help=_("sets the verbosity level and implies --log."
+                               ' "info" displays the full tracebacks of errors and shows all commands run.'
+                               ' "debug" adds the output of all command run.'))
     parser.add_argument("--no-download-checks",
                         action="store_true",
                         help=_("do not download checks, but use previously downloaded checks instead (only works with --local)"))
@@ -284,20 +313,24 @@ def main():
     global SLUG
     SLUG = args.slug
 
+    # dev implies offline and verbose "info" if not overwritten
     if args.dev:
         args.offline = True
-        args.verbose = True
+        if not args.verbose:
+            args.verbose = "info"
 
+    # offline implies local
     if args.offline:
         args.no_install_dependencies = True
         args.no_download_checks = True
         args.local = True
 
+    # Setting any verbosity level implies logs from checks
     if args.verbose:
-        # Show lib50 commands being run in verbose mode
-        logging.basicConfig(level=os.environ.get("CHECK50_LOGLEVEL", "INFO"))
-        lib50.ProgressBar.DISABLED = True
         args.log = True
+
+    # Setup logging for lib50 depending on verbosity level
+    setup_logging(args.verbose)
 
     # Warning in case of running remotely with no_download_checks or no_install_dependencies set
     if (args.no_download_checks or args.no_install_dependencies) and not args.local:
@@ -314,23 +347,25 @@ def main():
     args.output = [output for output in args.output if not (output in seen_output or seen_output.add(output))]
 
     # Set excepthook
-    excepthook.verbose = args.verbose
+    excepthook.verbose = bool(args.verbose)
     excepthook.outputs = args.output
     excepthook.output_file = args.output_file
 
+    # If remote, push files to GitHub and await results
     if not args.local:
         commit_hash = lib50.push("check50", SLUG, internal.CONFIG_LOADER, data={"check50": True})[1]
         with lib50.ProgressBar("Waiting for results") if "ansi" in args.output else nullcontext():
             tag_hash, results = await_results(commit_hash, SLUG)
+    # Otherwise run checks locally
     else:
-        with lib50.ProgressBar("Checking") if not args.verbose and "ansi" in args.output else nullcontext():
+        with lib50.ProgressBar("Checking") if "ansi" in args.output else nullcontext():
             # If developing, assume slug is a path to check_dir
             if args.dev:
                 internal.check_dir = Path(SLUG).expanduser().resolve()
                 if not internal.check_dir.is_dir():
                     raise internal.Error(_("{} is not a directory").format(internal.check_dir))
+            # Otherwise have lib50 create a local copy of slug
             else:
-                # Otherwise have lib50 create a local copy of slug
                 try:
                     internal.check_dir = lib50.local(SLUG, offline=args.no_download_checks)
                 except lib50.ConnectionError:
@@ -340,6 +375,7 @@ def main():
 
             # Load config
             config = internal.load_config(internal.check_dir)
+
             # Compile local checks if necessary
             if isinstance(config["checks"], dict):
                 config["checks"] = internal.compile_checks(config["checks"], prompt=args.dev)
@@ -354,16 +390,15 @@ def main():
             # Have lib50 decide which files to include
             included = lib50.files(config.get("files"))[0]
 
-            # Only open devnull conditionally
-            ctxmanager = open(os.devnull, "w") if not args.verbose else nullcontext()
-            with ctxmanager as devnull:
+            with open(os.devnull, "w") if args.verbose else nullcontext() as devnull:
+                # Redirect stdout to devnull if some verbosity level is set
                 if args.verbose:
+                    stdout = stderr = devnull
+                else:
                     stdout = sys.stdout
                     stderr = sys.stderr
-                else:
-                    stdout = stderr = devnull
 
-                # Create a working_area (temp dir) with all included student files named -
+                # Create a working_area (temp dir) named - with all included student files
                 with lib50.working_area(included, name='-') as working_area, \
                         contextlib.redirect_stdout(stdout), \
                         contextlib.redirect_stderr(stderr):

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -351,14 +351,7 @@ def main():
                         contextlib.redirect_stdout(stdout), \
                         contextlib.redirect_stderr(stderr):
 
-                    runner = CheckRunner(checks_file)
-
-                    # Run checks
-                    if args.target:
-                        check_results = runner.run(args.target, included, working_area)
-                    else:
-                        check_results = runner.run_all(included, working_area)
-
+                    check_results = CheckRunner(checks_file).run(included, working_area, args.target)
                     results = {
                         "slug": SLUG,
                         "results": [attr.asdict(result) for result in check_results],

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -377,7 +377,7 @@ def main():
                 output_file.write(renderer.to_ansi(**results, log=args.log))
                 output_file.write("\n")
             elif output == "html":
-                if os.environ.get("CS50_IDE_TYPE"):
+                if os.environ.get("CS50_IDE_TYPE") and args.local:
                     html = renderer.to_html(**results)
                     subprocess.check_call(["c9", "exec", "renderresults", "check50", html])
                 else:

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -377,18 +377,19 @@ def main():
                 output_file.write(renderer.to_ansi(**results, log=args.log))
                 output_file.write("\n")
             elif output == "html":
-                if not args.local:
-                    url = f"https://submit.cs50.io/check50/{tag_hash}"
-                else:
+                if os.environ.get("CS50_IDE_TYPE"):
                     html = renderer.to_html(**results)
-                    if os.environ.get("CS50_IDE_TYPE"):
-                        subprocess.check_call(["c9", "exec", "renderresults", "check50", html])
-                    else:
+                    subprocess.check_call(["c9", "exec", "renderresults", "check50", html])
+                else:
+                    if args.local:
+                        html = renderer.to_html(**results)
                         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".html") as html_file:
                             html_file.write(html)
                         url = f"file://{html_file.name}"
-                termcolor.cprint(_("To see the results in your browser go to {}").format(url), "white", attrs=["bold"])
+                    else:
+                        url = f"https://submit.cs50.io/check50/{tag_hash}"
 
+                    termcolor.cprint(_("To see the results in your browser go to {}").format(url), "white", attrs=["bold"])
 
 
 if __name__ == "__main__":

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -169,14 +169,10 @@ def setup_logging(level):
     if not level:
         return
 
+    lib50_logger = logging.getLogger("lib50")    
+
     # Set verbosity level on the lib50 logger
-    lib50_logger = logging.getLogger("lib50")
-    if level == "debug":
-        lib50_logger.setLevel(logging.DEBUG)
-    elif level == "info":
-        lib50_logger.setLevel(logging.INFO)
-    else:
-        raise ValueError(f'Unknown logging level: "{level}"')
+    lib50_logger.setLevel(getattr(logging, level.upper()))
 
     # Direct all logs to sys.stderr
     lib50_logger.addHandler(logging.StreamHandler(sys.stderr))
@@ -293,10 +289,11 @@ def main():
                         nargs="?",
                         default="",
                         const="info",
-                        choices=["info", "debug"],
-                        help=_("sets the verbosity level and implies --log."
-                               ' "info" displays the full tracebacks of errors and shows all commands run.'
-                               ' "debug" adds the output of all command run.'))
+                        choices=[attr for attr in dir(logging) if attr.isupper() and isinstance(getattr(logging, attr), int)],
+                        type=str.upper,
+                        help=_("sets the verbosity level."
+                               ' "INFO" displays the full tracebacks of errors and shows all commands run.'
+                               ' "DEBUG" adds the output of all command run.'))
     parser.add_argument("--no-download-checks",
                         action="store_true",
                         help=_("do not download checks, but use previously downloaded checks instead (only works with --local)"))
@@ -324,10 +321,6 @@ def main():
         args.no_install_dependencies = True
         args.no_download_checks = True
         args.local = True
-
-    # Setting any verbosity level implies logs from checks
-    if args.verbose:
-        args.log = True
 
     # Setup logging for lib50 depending on verbosity level
     setup_logging(args.verbose)

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -326,14 +326,16 @@ def main():
     setup_logging(args.verbose)
 
     # Warning in case of running remotely with no_download_checks or no_install_dependencies set
-    if (args.no_download_checks or args.no_install_dependencies) and not args.local:
+    if args.local:
         useless_args = []
         if args.no_download_checks:
             useless_args.append("--no-downloads-checks")
         if args.no_install_dependencies:
             useless_args.append("--no-install-dependencies")
-        termcolor.cprint(_("Warning: you should always use --local when using: {}".format(", ".join(useless_args))),
-            "yellow", attrs=["bold"])
+
+        if useless_args:
+            termcolor.cprint(_("Warning: you should always use --local when using: {}".format(", ".join(useless_args))),
+                "yellow", attrs=["bold"])
 
     # Filter out any duplicates from args.output
     seen_output = set()

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -169,7 +169,7 @@ def setup_logging(level):
     if not level:
         return
 
-    lib50_logger = logging.getLogger("lib50")    
+    lib50_logger = logging.getLogger("lib50")
 
     # Set verbosity level on the lib50 logger
     lib50_logger.setLevel(getattr(logging, level.upper()))
@@ -327,13 +327,13 @@ def main():
 
     # Warning in case of running remotely with no_download_checks or no_install_dependencies set
     if (args.no_download_checks or args.no_install_dependencies) and not args.local:
-        if args.no_download_checks and args.no_install_dependencies:
-            msg = _("--no-downloads-checks and --no-install-dependencies have")
-        elif args.no_download_checks:
-            msg = _("--no-downloads-checks has")
-        else:
-            msg = _("--no-install-dependencies has")
-        termcolor.cprint(_("Warning: {} no effect without --local").format(msg), "yellow", attrs=["bold"])
+        useless_args = []
+        if args.no_download_checks:
+            useless_args.append("--no-downloads-checks")
+        if args.no_install_dependencies:
+            useless_args.append("--no-install-dependencies")
+        termcolor.cprint(_("Warning: you should always use --local when using: {}".format(", ".join(useless_args))),
+            "yellow", attrs=["bold"])
 
     # Filter out any duplicates from args.output
     seen_output = set()

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -454,7 +454,7 @@ def _raw(s):
 
     s = f'"{repr(s)[1:-1]}"'
     if len(s) > 15:
-        s = s[:15] + "..."  # Truncate if too long
+        s = s[:15] + "...\""  # Truncate if too long
     return s
 
 

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -452,7 +452,7 @@ def _raw(s):
     if s == EOF:
         return "EOF"
 
-    s = f'"{repr(s)[1:-1]}"'
+    s = f'"{repr(str(s))[1:-1]}"'
     if len(s) > 15:
         s = s[:15] + "...\""  # Truncate if too long
     return s

--- a/check50/internal.py
+++ b/check50/internal.py
@@ -178,6 +178,7 @@ def import_file(name, path):
     spec.loader.exec_module(mod)
     return mod
 
+
 def _yes_no_prompt(prompt):
     """
     Raise a prompt, returns True if yes is entered, False if no is entered.

--- a/check50/renderer/templates/results.html
+++ b/check50/renderer/templates/results.html
@@ -24,6 +24,8 @@
                       <div class="well well-sm">
                           {# Reason why the check received its status #}
                           {% if check.cause %}
+                          <p>
+                              <b>Cause</b><br/>
                               {% autoescape false %}
                                   {{ check.cause.rationale | e | replace(" ", "&nbsp;") }}
                               {% endautoescape %}
@@ -34,16 +36,20 @@
                                       <br/>
                                   {% endif %}
                               {% endautoescape %}
+                          </p>
                           {% endif %}
 
                           {# Log information #}
                           {% if check.log %}
-                              <b>Log</b>
-                              <br/>
-                              {% for item in check.log %}
-                                  {{ item }}
-                                  <br/>
-                              {% endfor %}
+                              <samp>
+                                  <b>Log</b><br/>
+                                  <div style="border:2px solid; padding:2px;">
+                                      {% for item in check.log %}
+                                          {{ item }}
+                                          <br/>
+                                      {% endfor %}
+                                  </div>
+                              </samp>
                           {% endif %}
 
                           {% if check.cause and check.cause.error %}
@@ -97,6 +103,38 @@
                                                   {% set actual = check.cause.actual | e %}
                                               {% endif %}
                                               {{ actual | replace(" ", "&nbsp;") | replace("\n", "<br/>") }}
+                                          {% endautoescape %}
+                                      </samp>
+                                      </div>
+                                  </div>
+                              </div>
+                          {% endif %}
+
+                          {# Missing if there was one #}
+                          {% if check.cause and "missing_item" in check.cause and "collection" in check.cause %}
+                              <br/>
+
+                              <div class="row">
+                                  <div class="col-md-6">
+                                      <b>Could not find the following in the output:</b>
+                                      <br/>
+                                      <div style="background-color:black; color:#90ee90;">
+                                      <samp>
+                                          {% autoescape false %}
+                                              {% set item = check.cause.missing_item | e %}
+                                              {{ item | replace(" ", "&nbsp;") | replace("\n", "<br/>") }}
+                                          {% endautoescape %}
+                                      </samp>
+                                      </div>
+                                  </div>
+                                  <div class="col-md-6">
+                                      <b>Actual Output:</b>
+                                      <br/>
+                                      <div style="background-color:black; color:white;">
+                                      <samp>
+                                          {% autoescape false %}
+                                              {% set collection = check.cause.collection | e %}
+                                              {{ collection | replace(" ", "&nbsp;") | replace("\n", "<br/>") }}
                                           {% endautoescape %}
                                       </samp>
                                       </div>

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -252,7 +252,7 @@ class CheckRunner:
         deps = set()
         for target in targets:
             if target not in inverse_graph:
-                raise internal.Error(_("Unknown check: {}").format(e.args[0]))
+                raise internal.Error(_("Unknown check: {}").format(target))
             curr_check = target
             while curr_check is not None and curr_check not in deps:
                 deps.add(curr_check)

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -275,7 +275,7 @@ class CheckRunner:
         Recursively skip the children of check_name (presumably because check_name
         did not pass).
         """
-        for name, description in self.dependency_map[check_name]:
+        for name, description in self.dependency_graph[check_name]:
             if results[name] is None:
                 results[name] = CheckResult(name=name, description=_(description),
                                             passed=None,

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -275,7 +275,7 @@ class CheckRunner:
         Recursively skip the children of check_name (presumably because check_name
         did not pass).
         """
-        for name, description in self.dependency_[check_name]:
+        for name, description in self.dependency_graph[check_name]:
             if results[name] is None:
                 results[name] = CheckResult(name=name, description=_(description),
                                             passed=None,

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -178,28 +178,35 @@ class CheckRunner:
         _check_names.clear()
 
         # Map each check to tuples containing the names and descriptions of the checks that depend on it
-        self.dependency_map = collections.defaultdict(set)
+        self.dependency_graph = collections.defaultdict(set)
         for name, check in inspect.getmembers(check_module, lambda f: hasattr(f, "_check_dependency")):
             dependency = check._check_dependency.__name__ if check._check_dependency is not None else None
-            self.dependency_map[dependency].add((name, check.__doc__))
+            self.dependency_graph[dependency].add((name, check.__doc__))
 
 
-    def run_all(self, files, working_area):
+    def run(self, files, working_area, targets=None):
         """
         Run checks concurrently.
         Returns a list of CheckResults ordered by declaration order of the checks in the imported module
+        targets allows you to limit which checks run. If targets is false-y, all checks are run.
         """
+
+        graph = self.build_subgraph(targets) if targets else self.dependency_graph
 
         # Ensure that dictionary is ordered by check declaration order (via self.check_names)
         # NOTE: Requires CPython 3.6. If we need to support older versions of Python, replace with OrderedDict.
         results = {name: None for name in self.check_names}
         checks_root = working_area.parent
-        max_workers = os.environ.get("CHECK50_WORKERS")
-        with futures.ProcessPoolExecutor(max_workers=max_workers if max_workers is None else int(max_workers)) as executor:
 
+        try:
+            max_workers = int(os.environ.get("CHECK50_WORKERS"))
+        except (ValueError, TypeError):
+            max_workers = None
+
+        with futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
             # Start all checks that have no dependencies
             not_done = set(executor.submit(run_check(name, self.checks_spec, checks_root))
-                           for name, _ in self.dependency_map[None])
+                           for name, _ in graph[None])
             not_passed = []
 
             while not_done:
@@ -210,7 +217,7 @@ class CheckRunner:
                     results[result.name] = result
                     if result.passed:
                         # Dispatch dependent checks
-                        for child_name, _ in self.dependency_map[result.name]:
+                        for child_name, _ in graph[result.name]:
                             not_done.add(executor.submit(
                                 run_check(child_name, self.checks_spec, checks_root, state)))
                     else:
@@ -219,74 +226,48 @@ class CheckRunner:
         for name in not_passed:
             self._skip_children(name, results)
 
-        return list(results.values())
+        # Don't include checks we don't have results for (i.e. in the case that targets != None) in the list.
+        return list(filter(None, results.values()))
 
 
-    def run(self, check_names, files, working_area):
+    def build_subgraph(self, targets):
         """
-        Run just the targeted checks, and the checks they depends on.
-        Returns just the result of the targetted checks.
+        Build minimal subgraph of self.dependency_graph that contains each check in targets
         """
-        if len(set(check_names)) < len(check_names):
-            raise internal.Error(_("Duplicate checks targetted: {}".format(check_names)))
-
-        # Find the docs for every check in the dependency map
-        check_docs = {}
-        for dependents in self.dependency_map.values():
-            for dependent, doc in dependents:
-                check_docs[dependent] = doc
-
-        # For every targetted check, validate that it exists
-        for check_name in check_names:
-            if check_name not in check_docs:
-                raise internal.Error(_("Unknown check {}").format(check_name))
-
-        # Build an inverse dependency map, from a check to its dependency
-        inverse_dependency_map = self._create_inverse_dependency_map()
-
-        # Reconstruct a new dependency_map, consisting of the targetted checks and their dependencies
-        new_dependency_map = collections.defaultdict(set)
-        for check_name in check_names:
-            cur_check_name = check_name
-            while cur_check_name != None:
-                dependency_name = inverse_dependency_map[cur_check_name]
-                new_dependency_map[dependency_name].add((cur_check_name, check_docs[cur_check_name]))
-                cur_check_name = dependency_name
-
-        # Temporarily replace dependency_map and run
-        try:
-            old_dependency_map = self.dependency_map
-            self.dependency_map = new_dependency_map
-            results = self.run_all(files, working_area)
-        finally:
-            self.dependency_map = old_dependency_map
-
-        # Filter out all occurances of None in results (results of non targetted checks)
-        return [result for result in results if result != None]
+        checks = self.dependencies_of(targets)
+        subgraph = collections.defaultdict(set)
+        for dep, children in self.dependency_graph.items():
+            # If dependency is not in checks, none of its children will be, may as well skip.
+            if dep is not None and dep not in checks:
+                continue
+            for child in children:
+                if child[0] in checks:
+                    subgraph[dep].add(child)
+        return subgraph
 
 
-    def dependencies_of(self, check_names):
-        """Get the names of all direct and indirect dependencies of check_names."""
-        # Build an inverse dependency map, from a check to its dependency
-        inverse_dependency_map = self._create_inverse_dependency_map()
 
-        # Gather all dependencies from inverse_dependency_map
-        dependencies = set()
-        for check_name in check_names:
-            cur_check_name = inverse_dependency_map[check_name]
-            while cur_check_name != None:
-                dependencies.add(cur_check_name)
-                cur_check_name = inverse_dependency_map[cur_check_name]
+    def dependencies_of(self, targets):
+        inverse_graph = self._create_inverse_dependency_graph()
+        deps = set()
+        for target in targets:
+            if target not in inverse_graph:
+                raise internal.Error(_("Unknown check: {}").format(e.args[0]))
+            curr_check = target
+            while curr_check is not None and curr_check not in deps:
+                deps.add(curr_check)
+                curr_check = inverse_graph[curr_check]
+        return deps
 
-        return dependencies
 
-    def _create_inverse_dependency_map(self):
+
+    def _create_inverse_dependency_graph(self):
         """Build an inverse dependency map, from a check to its dependency."""
-        inverse_dependency_map = {}
-        for check_name, dependents in self.dependency_map.items():
+        inverse_dependency_graph = {}
+        for check_name, dependents in self.dependency_graph.items():
             for dependent_name, _ in dependents:
-                inverse_dependency_map[dependent_name] = check_name
-        return inverse_dependency_map
+                inverse_dependency_graph[dependent_name] = check_name
+        return inverse_dependency_graph
 
 
     def _skip_children(self, check_name, results):

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -37,7 +37,7 @@ class CheckResult:
         """Create a check_result given a check function, automatically recording the name,
         the dependency, and the (translated) description.
         """
-        return cls(name=check.__name__, description=_(check.__doc__),
+        return cls(name=check.__name__, description=_(check.__doc__ if check.__doc__ else check.__name__.replace("_", " ")),
                    dependency=check._check_dependency.__name__ if check._check_dependency else None,
                    *args,
                    **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.0.8",
+    version="3.0.9",
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.0.9",
+    version="3.0.10",
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     message_extractors = {
         'check50': [('**.py', 'python', None),],
     },
-    install_requires=["attrs>=18", "bs4>=0", "pexpect>=4.6", "lib50>=2,<3", "pyyaml>=3.10", "requests>=2.19", "termcolor>=1.1", "jinja2>=2.10"],
+    install_requires=["attrs>=18", "bs4>=0", "pexpect>=4.6", "lib50>=2,<4", "pyyaml>=3.10", "requests>=2.19", "termcolor>=1.1", "jinja2>=2.10"],
     extras_require = {
         "develop": ["sphinx", "sphinx_rtd_theme"]
     },

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     message_extractors = {
         'check50': [('**.py', 'python', None),],
     },
-    install_requires=["attrs>=18", "bs4>=0", "pexpect>=4.6", "lib50>=2,<3", "pyyaml>=3.10", "requests>=2.19", "termcolor>=1.1", "jinja2>=2.10"],
+    install_requires=["attrs>=18", "bs4>=0", "pexpect>=4.6", "lib50>=2.1,<3", "pyyaml>=3.10", "requests>=2.19", "termcolor>=1.1", "jinja2>=2.10"],
     extras_require = {
         "develop": ["sphinx", "sphinx_rtd_theme"]
     },

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-if __import__("os").name == "nt":
-    raise RuntimeError("check50 does not support Windows directly. Instead, you should install the Windows Subsystem for Linux (https://docs.microsoft.com/en-us/windows/wsl/install-win10) and then install check50 within that.")
-
 from setuptools import setup
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+if __import__("os").name == "nt":
+    raise RuntimeError("check50 does not support Windows directly. Instead, you should install the Windows Subsystem for Linux (https://docs.microsoft.com/en-us/windows/wsl/install-win10) and then install check50 within that.")
+
 from setuptools import setup
 
 setup(
@@ -14,7 +17,7 @@ setup(
     message_extractors = {
         'check50': [('**.py', 'python', None),],
     },
-    install_requires=["attrs>=18", "bs4>=0", "pexpect>=4.6", "lib50>=2.1,<3", "pyyaml>=3.10", "requests>=2.19", "termcolor>=1.1", "jinja2>=2.10"],
+    install_requires=["attrs>=18", "bs4>=0", "pexpect>=4.6", "lib50>=2,<3", "pyyaml>=3.10", "requests>=2.19", "termcolor>=1.1", "jinja2>=2.10"],
     extras_require = {
         "develop": ["sphinx", "sphinx_rtd_theme"]
     },

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.0.9",
+    version="3.0.8",
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.0.10",
+    version="3.1.0",
     include_package_data=True
 )

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -149,14 +149,12 @@ class TestProcessStdout(Base):
         self.process.stdout("foo\n")
         self.process.stdout("bar")
         self.process.stdout("\n")
-        self.assertTrue(self.process.process.isalive())
 
     def test_out_regex(self):
         self.write("print('foo')")
         self.runpy()
         self.process.stdout(".o.")
         self.process.stdout("\n")
-        self.assertTrue(self.process.process.isalive())
 
     def test_out_no_regex(self):
         self.write("print('foo')")

--- a/tests/check50_tests.py
+++ b/tests/check50_tests.py
@@ -321,7 +321,7 @@ class TestOutputModes(Base):
 class TestHiddenCheck(Base):
     def test_hidden_check(self):
         pexpect.run(f"check50 --dev -o json --output-file foo.json {CHECKS_DIRECTORY}/hidden")
-        expected = [{'name': 'check', 'description': None, 'passed': False, 'log': [], 'cause': {"rationale": "foo", "help": None}, 'data': {}, 'dependency': None}]
+        expected = [{'name': 'check', 'description': "check", 'passed': False, 'log': [], 'cause': {"rationale": "foo", "help": None}, 'data': {}, 'dependency': None}]
         with open("foo.json", "r") as f:
             self.assertEqual(json.load(f)["results"], expected)
 


### PR DESCRIPTION
`--offline` is broken up and now implies `--no-install-dependencies` and `--no-download-checks`.

`--verbose info` and `--verbose debug` now exist. The latter gives you all command output from `git`

Logging is no longer set by an env var, instead it's set through the `--verbose` flag.