### PR TITLE
Log limit

### DIFF
--- a/check50/c.py
+++ b/check50/c.py
@@ -14,7 +14,7 @@ CC = "clang"
 CFLAGS = {"std": "c11", "ggdb": True, "lm": True}
 
 
-def compile(*files, exe_name=None, cc=CC, **cflags):
+def compile(*files, exe_name=None, cc=CC, max_log_lines=50, **cflags):
     """
     Compile C source files.
 
@@ -62,7 +62,7 @@ def compile(*files, exe_name=None, cc=CC, **cflags):
 
     # Log the last 50 lines of output in case compilation fails
     if process.exitcode != 0:
-        for line in stdout.splitlines()[-50:]:
+        for line in stdout.splitlines()[-max_log_lines:]:
             log(line)
         raise Failure("code failed to compile")
 

--- a/check50/c.py
+++ b/check50/c.py
@@ -60,8 +60,9 @@ def compile(*files, exe_name=None, cc=CC, **cflags):
     # Strip out ANSI codes
     stdout = re.sub(r"\x1B\[[0-?]*[ -/]*[@-~]", "",  process.stdout())
 
+    # Log the last 50 lines of output in case compilation fails
     if process.exitcode != 0:
-        for line in stdout.splitlines():
+        for line in stdout.splitlines()[-50:]:
             log(line)
         raise Failure("code failed to compile")
 

--- a/check50/c.py
+++ b/check50/c.py
@@ -60,7 +60,7 @@ def compile(*files, exe_name=None, cc=CC, max_log_lines=50, **cflags):
     # Strip out ANSI codes
     stdout = re.sub(r"\x1B\[[0-?]*[ -/]*[@-~]", "",  process.stdout())
 
-    # Log the last 50 lines of output in case compilation fails
+    # Log the last max_log_lines lines of output in case compilation fails
     if process.exitcode != 0:
         for line in stdout.splitlines()[-max_log_lines:]:
             log(line)

--- a/check50/c.py
+++ b/check50/c.py
@@ -60,10 +60,16 @@ def compile(*files, exe_name=None, cc=CC, max_log_lines=50, **cflags):
     # Strip out ANSI codes
     stdout = re.sub(r"\x1B\[[0-?]*[ -/]*[@-~]", "",  process.stdout())
 
-    # Log the last max_log_lines lines of output in case compilation fails
+    # Log max_log_lines lines of output in case compilation fails
     if process.exitcode != 0:
-        for line in stdout.splitlines()[-max_log_lines:]:
+        lines = stdout.splitlines()
+
+        if len(lines) > max_log_lines:
+            lines = lines[:max_log_lines // 2] + lines[-(max_log_lines // 2):]
+
+        for line in lines:
             log(line)
+
         raise Failure("code failed to compile")
 
 

--- a/check50/renderer/templates/results.html
+++ b/check50/renderer/templates/results.html
@@ -43,7 +43,7 @@
                           {% if check.log %}
                               <samp>
                                   <b>Log</b><br/>
-                                  <div style="border:2px solid; padding:2px;">
+                                  <div style="border:2px solid; padding:2px; max-height:20em; overflow:scroll;">
                                       {% for item in check.log %}
                                           {{ item }}
                                           <br/>

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -155,7 +155,7 @@ def check(dependency=None, timeout=60):
             else:
                 result.passed = True
             finally:
-                result.log = _log
+                result.log = _log if len(_log) <= 1 else ["..."] + _log[-100:]
                 result.data = _data
                 return result, state
         return wrapper

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -155,7 +155,7 @@ def check(dependency=None, timeout=60):
             else:
                 result.passed = True
             finally:
-                result.log = _log if len(_log) <= 1 else ["..."] + _log[-100:]
+                result.log = _log if len(_log) <= 100 else ["..."] + _log[-100:]
                 result.data = _data
                 return result, state
         return wrapper

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -80,13 +80,15 @@ def _timeout(seconds):
         signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
 
-def check(dependency=None, timeout=60):
+def check(dependency=None, timeout=60, max_log_lines=100):
     """Mark function as a check.
 
     :param dependency: the check that this check depends on
     :type dependency: function
     :param timeout: maximum number of seconds the check can run
     :type timeout: int
+    :param max_log_lines: maximum number of lines that can appear in the log
+    :type max_log_lines: int
 
     When a check depends on another, the former will only run if the latter passes.
     Additionally, the dependent check will inherit the filesystem of its dependency.
@@ -155,7 +157,7 @@ def check(dependency=None, timeout=60):
             else:
                 result.passed = True
             finally:
-                result.log = _log if len(_log) <= 100 else ["..."] + _log[-100:]
+                result.log = _log if len(_log) <= max_log_lines else ["..."] + _log[-max_log_lines:]
                 result.data = _data
                 return result, state
         return wrapper


### PR DESCRIPTION
With clang potentially spewing out a 1000+ lines of output as per https://github.com/cs50/submit.cs50.io/issues/126 it seemed reasonable to impose a limit on logs. This PR limits the number of log lines from clang to a default of 50, and the total number of lines in the log to a default of 100. Both are configurable through a kwarg `max_log_lines`.

While I was at it, I limited the `max height` of the log in the webview and made it scroll on overflow.