### PR TITLE
Tests update

### DIFF
--- a/tests/c_tests.py
+++ b/tests/c_tests.py
@@ -28,6 +28,12 @@ class Base(unittest.TestCase):
         self.working_directory.cleanup()
 
 class TestCompile(Base):
+    def test_compile_incorrect(self):
+        open("blank.c", "w").close()
+
+        with self.assertRaises(check50.Failure):
+            check50.c.compile("blank.c")
+
     def test_compile_hello_world(self):
         with open("hello.c", "w") as f:
             src =   '#include <stdio.h>\n'\

--- a/tests/check50_tests.py
+++ b/tests/check50_tests.py
@@ -58,13 +58,25 @@ class TestExitPy(Base):
         process.expect_exact("can't check until a frown turns upside down")
         process.close(force=True)
 
-    def test_with_file(self):
+    def test_with_correct_file(self):
         open("foo.py", "w").close()
         process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/exit_py")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact(":)")
         process.expect_exact("foo.py exits properly")
+        process.close(force=True)
+
+    def test_with_incorrect_file(self):
+        with open("foo.py", "w") as f:
+            f.write("from sys import exit\nexit(1)")
+
+        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/exit_py")
+        process.expect_exact(":)")
+        process.expect_exact("foo.py exists")
+        process.expect_exact(":(")
+        process.expect_exact("foo.py exits properly")
+        process.expect_exact("expected exit code 0, not 1")
         process.close(force=True)
 
 


### PR DESCRIPTION
This adds two test cases -- one to `check50_tests`, for when a Python file exists but it returns an unexpected error code; one to `c_tests`, for when a C file compiles incorrectly.