### PR TITLE
Allow for "spawn"

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -53,10 +53,10 @@ def yes_no_prompt(prompt):
 
 
 # Assume we should print tracebacks until we get command line arguments
-internal.excepthook.verbose = True
-internal.excepthook.outputs = ("ansi",)
-internal.excepthook.output_file = None
-sys.excepthook = internal.excepthook
+internal._excepthook.verbose = True
+internal._excepthook.outputs = ("ansi",)
+internal._excepthook.output_file = None
+sys.excepthook = internal._excepthook
 
 
 def install_dependencies(dependencies, verbose=False):
@@ -294,9 +294,9 @@ def main():
     args.output = [output for output in args.output if not (output in seen_output or seen_output.add(output))]
 
     # Set excepthook
-    internal.excepthook.verbose = bool(args.verbose)
-    internal.excepthook.outputs = args.output
-    internal.excepthook.output_file = args.output_file
+    internal._excepthook.verbose = bool(args.verbose)
+    internal._excepthook.outputs = args.output
+    internal._excepthook.output_file = args.output_file
 
     # If remote, push files to GitHub and await results
     if not args.local:

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -401,6 +401,10 @@ class Missing(Failure):
 
     def __init__(self, missing_item, collection, help=None):
         super().__init__(rationale=_("Did not find {} in {}").format(_raw(missing_item), _raw(collection)), help=help)
+
+        if missing_item == EOF:
+            missing_item = "EOF"
+
         self.payload.update({"missing_item": str(missing_item), "collection": str(collection)})
 
 

--- a/check50/internal.py
+++ b/check50/internal.py
@@ -2,13 +2,15 @@
 Additional check50 internals exposed to extension writers in addition to the standard API
 """
 
-import importlib
 from pathlib import Path
+import importlib
+import json
 import sys
+import traceback
 
 import lib50
 
-from . import _simple
+from . import _simple, __version__
 
 #: Directory containing the check and its associated files
 check_dir = None
@@ -18,6 +20,9 @@ run_dir = None
 
 #: Boolean that indicates if a check is currently running
 check_running = False
+
+#: The user specified slug used to indentifies the set of checks
+slug = None
 
 #: ``lib50`` config loader
 CONFIG_LOADER = lib50.config.Loader("check50")
@@ -111,7 +116,7 @@ def excepthook(cls, exc, tb):
             ctxmanager = open(excepthook.output_file, "w") if excepthook.output_file else nullcontext(sys.stdout)
             with ctxmanager as output_file:
                 json.dump({
-                    "slug": SLUG,
+                    "slug": slug,
                     "error": {
                         "type": cls.__name__,
                         "value": str(exc),

--- a/check50/internal.py
+++ b/check50/internal.py
@@ -94,61 +94,6 @@ class Register:
 register = Register()
 
 
-def excepthook(cls, exc, tb):
-    """
-    check50's excepthook with configurable error output.
-
-    :ivar excepthook.verbose: show the full tracebook iff set to True
-    :vartype excepthook.verbose: bool
-    :ivar excepthook.outputs: in which format errors should be returned (can be multiple)
-    :vartype excepthook.outputs: tuple of strings, any of "json", "ansi", "html"
-    :ivar excepthook.output_file: file to which the output should be redirected
-    :vartype excepthook.output_file: str or pathlib.Path
-
-    See also: https://docs.python.org/3/library/sys.html#sys.excepthook
-    """
-
-    # All channels to output to
-    outputs = excepthook.outputs
-
-    for output in excepthook.outputs:
-        outputs.remove(output)
-        if output == "json":
-            ctxmanager = open(excepthook.output_file, "w") if excepthook.output_file else nullcontext(sys.stdout)
-            with ctxmanager as output_file:
-                json.dump({
-                    "slug": slug,
-                    "error": {
-                        "type": cls.__name__,
-                        "value": str(exc),
-                        "traceback": traceback.format_tb(exc.__traceback__),
-                        "data" : exc.payload if hasattr(exc, "payload") else {}
-                    },
-                    "version": __version__
-                }, output_file, indent=4)
-                output_file.write("\n")
-
-        elif output == "ansi" or output == "html":
-            if (issubclass(cls, Error) or issubclass(cls, lib50.Error)) and exc.args:
-                termcolor.cprint(str(exc), "red", file=sys.stderr)
-            elif issubclass(cls, FileNotFoundError):
-                termcolor.cprint(_("{} not found").format(exc.filename), "red", file=sys.stderr)
-            elif issubclass(cls, KeyboardInterrupt):
-                termcolor.cprint(f"check cancelled", "red")
-            elif not issubclass(cls, Exception):
-                # Class is some other BaseException, better just let it go
-                return
-            else:
-                termcolor.cprint(_("Sorry, something's wrong! Let sysadmins@cs50.harvard.edu know!"), "red", file=sys.stderr)
-
-            if excepthook.verbose:
-                traceback.print_exception(cls, exc, tb)
-                if hasattr(exc, "payload"):
-                    print("Exception payload:", json.dumps(exc.payload), sep="\n")
-
-    sys.exit(1)
-
-
 def load_config(check_dir):
     """
     Load configuration file from ``check_dir / ".cs50.yaml"``, applying
@@ -238,6 +183,61 @@ def import_file(name, path):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _excepthook(cls, exc, tb):
+    """
+    check50's excepthook with configurable error output.
+
+    :ivar _excepthook.verbose: show the full tracebook iff set to True
+    :vartype _excepthook.verbose: bool
+    :ivar _excepthook.outputs: in which format errors should be returned (can be multiple)
+    :vartype _excepthook.outputs: tuple of strings, any of "json", "ansi", "html"
+    :ivar _excepthook.output_file: file to which the output should be redirected
+    :vartype _excepthook.output_file: str or pathlib.Path
+
+    See also: https://docs.python.org/3/library/sys.html#sys.excepthook
+    """
+
+    # All channels to output to
+    outputs = _excepthook.outputs
+
+    for output in _excepthook.outputs:
+        outputs.remove(output)
+        if output == "json":
+            ctxmanager = open(_excepthook.output_file, "w") if _excepthook.output_file else nullcontext(sys.stdout)
+            with ctxmanager as output_file:
+                json.dump({
+                    "slug": slug,
+                    "error": {
+                        "type": cls.__name__,
+                        "value": str(exc),
+                        "traceback": traceback.format_tb(exc.__traceback__),
+                        "data" : exc.payload if hasattr(exc, "payload") else {}
+                    },
+                    "version": __version__
+                }, output_file, indent=4)
+                output_file.write("\n")
+
+        elif output == "ansi" or output == "html":
+            if (issubclass(cls, Error) or issubclass(cls, lib50.Error)) and exc.args:
+                termcolor.cprint(str(exc), "red", file=sys.stderr)
+            elif issubclass(cls, FileNotFoundError):
+                termcolor.cprint(_("{} not found").format(exc.filename), "red", file=sys.stderr)
+            elif issubclass(cls, KeyboardInterrupt):
+                termcolor.cprint(f"check cancelled", "red")
+            elif not issubclass(cls, Exception):
+                # Class is some other BaseException, better just let it go
+                return
+            else:
+                termcolor.cprint(_("Sorry, something's wrong! Let sysadmins@cs50.harvard.edu know!"), "red", file=sys.stderr)
+
+            if _excepthook.verbose:
+                traceback.print_exception(cls, exc, tb)
+                if hasattr(exc, "payload"):
+                    print("Exception payload:", json.dumps(exc.payload), sep="\n")
+
+    sys.exit(1)
 
 
 def _yes_no_prompt(prompt):

--- a/check50/internal.py
+++ b/check50/internal.py
@@ -128,7 +128,7 @@ def excepthook(cls, exc, tb):
                 output_file.write("\n")
 
         elif output == "ansi" or output == "html":
-            if (issubclass(cls, internal.Error) or issubclass(cls, lib50.Error)) and exc.args:
+            if (issubclass(cls, Error) or issubclass(cls, lib50.Error)) and exc.args:
                 termcolor.cprint(str(exc), "red", file=sys.stderr)
             elif issubclass(cls, FileNotFoundError):
                 termcolor.cprint(_("{} not found").format(exc.filename), "red", file=sys.stderr)

--- a/check50/internal.py
+++ b/check50/internal.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import importlib
 import json
 import sys
+import termcolor
 import traceback
 
 import lib50

--- a/check50/internal.py
+++ b/check50/internal.py
@@ -88,6 +88,61 @@ class Register:
 register = Register()
 
 
+def excepthook(cls, exc, tb):
+    """
+    check50's excepthook with configurable error output.
+
+    :ivar excepthook.verbose: show the full tracebook iff set to True
+    :vartype excepthook.verbose: bool
+    :ivar excepthook.outputs: in which format errors should be returned (can be multiple)
+    :vartype excepthook.outputs: tuple of strings, any of "json", "ansi", "html"
+    :ivar excepthook.output_file: file to which the output should be redirected
+    :vartype excepthook.output_file: str or pathlib.Path
+
+    See also: https://docs.python.org/3/library/sys.html#sys.excepthook
+    """
+
+    # All channels to output to
+    outputs = excepthook.outputs
+
+    for output in excepthook.outputs:
+        outputs.remove(output)
+        if output == "json":
+            ctxmanager = open(excepthook.output_file, "w") if excepthook.output_file else nullcontext(sys.stdout)
+            with ctxmanager as output_file:
+                json.dump({
+                    "slug": SLUG,
+                    "error": {
+                        "type": cls.__name__,
+                        "value": str(exc),
+                        "traceback": traceback.format_tb(exc.__traceback__),
+                        "data" : exc.payload if hasattr(exc, "payload") else {}
+                    },
+                    "version": __version__
+                }, output_file, indent=4)
+                output_file.write("\n")
+
+        elif output == "ansi" or output == "html":
+            if (issubclass(cls, internal.Error) or issubclass(cls, lib50.Error)) and exc.args:
+                termcolor.cprint(str(exc), "red", file=sys.stderr)
+            elif issubclass(cls, FileNotFoundError):
+                termcolor.cprint(_("{} not found").format(exc.filename), "red", file=sys.stderr)
+            elif issubclass(cls, KeyboardInterrupt):
+                termcolor.cprint(f"check cancelled", "red")
+            elif not issubclass(cls, Exception):
+                # Class is some other BaseException, better just let it go
+                return
+            else:
+                termcolor.cprint(_("Sorry, something's wrong! Let sysadmins@cs50.harvard.edu know!"), "red", file=sys.stderr)
+
+            if excepthook.verbose:
+                traceback.print_exception(cls, exc, tb)
+                if hasattr(exc, "payload"):
+                    print("Exception payload:", json.dumps(exc.payload), sep="\n")
+
+    sys.exit(1)
+
+
 def load_config(check_dir):
     """
     Load configuration file from ``check_dir / ".cs50.yaml"``, applying

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -291,7 +291,7 @@ class CheckRunner:
 
 class run_check:
     """
-    Check job that runs in the a child process.
+    Check job that runs in a seperate process.
     This is only a class to get around the fact that `pickle` can't serialize closures.
     This class is essentially a function that reimports the check module and runs the check.
     """

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -290,7 +290,8 @@ class CheckRunner:
 
 class run_check:
     """
-    Hack to get around the fact that `pickle` can't serialize closures.
+    Check job that runs in the a child process.
+    This is only a class to get around the fact that `pickle` can't serialize closures.
     This class is essentially a function that reimports the check module and runs the check.
     """
 

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -291,7 +291,7 @@ class CheckRunner:
 
 class run_check:
     """
-    Check job that runs in a seperate process.
+    Check job that runs in a separate process.
     This is only a class to get around the fact that `pickle` can't serialize closures.
     This class is essentially a function that reimports the check module and runs the check.
     """

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -301,9 +301,9 @@ class run_check:
     CROSS_PROCESS_ATTRIBUTES = (
         "internal.check_dir",
         "internal.slug",
-        "internal.excepthook.outputs",
-        "internal.excepthook.output_file",
-        "internal.excepthook.verbose"
+        "internal._excepthook.outputs",
+        "internal._excepthook.output_file",
+        "internal._excepthook.verbose"
     )
 
     def __init__(self, check_name, spec, checks_root, state=None):

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -301,7 +301,19 @@ class run_check:
         self.checks_root = checks_root
         self.state = state
 
+        # Carry over relevant module variables to the check process
+        self.check_dir = internal.check_dir
+        self.excepthook_outputs = internal.excepthook.outputs
+        self.excepthook_output_file = internal.excepthook.output_file
+        self.excepthook_verbose = internal.excepthook.verbose
+
     def __call__(self):
+        # Init module variables in check process
+        internal.check_dir = self.check_dir
+        internal.excepthook.outputs = self.excepthook_outputs
+        internal.excepthook.output_file = self.excepthook_output_file
+        internal.excepthook.verbose = self.excepthook_verbose
+
         mod = importlib.util.module_from_spec(self.spec)
         self.spec.loader.exec_module(mod)
         internal.check_running = True

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -303,6 +303,7 @@ class run_check:
 
         # Carry over relevant module variables to the check process
         self.check_dir = internal.check_dir
+        self.slug = internal.slug
         self.excepthook_outputs = internal.excepthook.outputs
         self.excepthook_output_file = internal.excepthook.output_file
         self.excepthook_verbose = internal.excepthook.verbose
@@ -310,6 +311,7 @@ class run_check:
     def __call__(self):
         # Init module variables in check process
         internal.check_dir = self.check_dir
+        internal.slug = self.slug
         internal.excepthook.outputs = self.excepthook_outputs
         internal.excepthook.output_file = self.excepthook_output_file
         internal.excepthook.verbose = self.excepthook_verbose


### PR DESCRIPTION
Python 3.8 uses spawn as default on MacOS (https://github.com/cs50/check50/issues/223). From the [Python docs](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods):

> The fork start method should be considered unsafe as it can lead to crashes of the subprocess. See [bpo-33725](https://bugs.python.org/issue33725).

This PR re-instantiates all the module attributes that should be set in each check process, and through that check50 now supports spawn. To do this `runner.run_check` keeps a tuple `attribute_names`. Upon initialization of `run_check` all attribute names are evaluated (`eval()`) and stored with `run_check`. Then upon running `run_check` in the check process each attribute gets set (`setattr()`) to the stored  value from the parent process. 