### PR TITLE
int and float support for run.stdout

### DIFF
--- a/check50/__init__.py
+++ b/check50/__init__.py
@@ -38,7 +38,7 @@ from ._api import (
     exists,
     hash,
     include,
-    number_regex,
+    regex,
     run,
     log, _log,
     hidden,
@@ -49,5 +49,5 @@ from ._api import (
 from .runner import check
 from pexpect import EOF
 
-__all__ = ["import_checks", "data", "exists", "hash", "include", "number_regex",
+__all__ = ["import_checks", "data", "exists", "hash", "include", "regex",
            "run", "log", "Failure", "Mismatch", "check", "EOF"]

--- a/check50/__init__.py
+++ b/check50/__init__.py
@@ -38,6 +38,7 @@ from ._api import (
     exists,
     hash,
     include,
+    number_regex,
     run,
     log, _log,
     hidden,
@@ -48,5 +49,5 @@ from ._api import (
 from .runner import check
 from pexpect import EOF
 
-__all__ = ["import_checks", "data", "exists", "hash", "include",
+__all__ = ["import_checks", "data", "exists", "hash", "include", "number_regex",
            "run", "log", "Failure", "Mismatch", "check", "EOF"]

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -140,11 +140,11 @@ def import_checks(path):
 def number_regex(number):
     """
     Create a regular expression to match the number exactly:
-        (?<!\d)number(?!\d|(\.\d))
+        (?<!\d)number(?!(\.?\d))
 
     (?<!\d) = negative behind, \
         asserts that there are no digits in front of the number.
-    (?!\d|(\.\d)) = negative lookahead, \
+    (?!(\.?\d)) = negative lookahead, \
         asserts that there are no digits and no . followed by digits after the number.
 
     :param number: the number to match in the regex
@@ -157,7 +157,7 @@ def number_regex(number):
         check50.run("./prog").stdout(check50.number_regex("7.0000"))
 
     """
-    return fr"(?<!\d){re.escape(str(number))}(?!\d|(\.\d))"
+    return fr"(?<!\d){re.escape(str(number))}(?!(\.?\d))"
 
 
 class run:

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -137,33 +137,33 @@ def import_checks(path):
     return mod
 
 
-def number_regex(number):
-    """
-    Create a regular expression to match the number exactly:
-        In case of a positive number:
-            (?<![\d\-])number(?!(\.?\d))
-        In case of a negative number:
-            number(?!(\.?\d))
+class regex:
+    @staticmethod
+    def decimal(number):
+        """
+        Create a regular expression to match the number exactly:
+            In case of a positive number:
+                (?<![\d\-])number(?!(\.?\d))
+            In case of a negative number:
+                number(?!(\.?\d))
 
-    (?<![\d\-]) = negative lookbehind, \
-        asserts that there are no digits and no - in front of the number.
-    (?!(\.?\d)) = negative lookahead, \
-        asserts that there are no digits and no additional . followed by digits after the number.
+        (?<![\d\-]) = negative lookbehind, \
+            asserts that there are no digits and no - in front of the number.
+        (?!(\.?\d)) = negative lookahead, \
+            asserts that there are no digits and no additional . followed by digits after the number.
 
-    :param number: the number to match in the regex
-    :type number: any numbers.Number (such as int, float, ...)
-    :rtype: str
+        :param number: the number to match in the regex
+        :type number: any numbers.Number (such as int, float, ...)
+        :rtype: str
 
-    Example usage::
+        Example usage::
 
-        # Check that 7.0000 is printed with 5 significant figures
-        check50.run("./prog").stdout(check50.number_regex("7.0000"))
+            # Check that 7.0000 is printed with 5 significant figures
+            check50.run("./prog").stdout(check50.regex.decimal("7.0000"))
 
-    """
-    if number < 0:
-        return fr"{re.escape(str(number))}(?!(\.?\d))"
-
-    return fr"(?<![\d\-]){re.escape(str(number))}(?!(\.?\d))"
+        """
+        negative_lookbehind = fr"(?<![\d\-])" if number >= 0 else ""
+        return fr"{negative_lookbehind}{re.escape(str(number))}(?!(\.?\d))"
 
 
 class run:
@@ -285,7 +285,7 @@ class run:
         # In case output is an int/float, use a regex to match exactly that int/float
         if isinstance(output, numbers.Number):
             regex = True
-            output = number_regex(output)
+            output = globals()["regex"].decimal(output)
 
         expect = self.process.expect if regex else self.process.expect_exact
 

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -140,12 +140,15 @@ def import_checks(path):
 def number_regex(number):
     """
     Create a regular expression to match the number exactly:
-        (?<!\d)number(?!(\.?\d))
+        In case of a positive number:
+            (?<![\d\-])number(?!(\.?\d))
+        In case of a negative number:
+            number(?!(\.?\d))
 
-    (?<!\d) = negative behind, \
-        asserts that there are no digits in front of the number.
+    (?<![\d\-]) = negative lookbehind, \
+        asserts that there are no digits and no - in front of the number.
     (?!(\.?\d)) = negative lookahead, \
-        asserts that there are no digits and no . followed by digits after the number.
+        asserts that there are no digits and no additional . followed by digits after the number.
 
     :param number: the number to match in the regex
     :type number: any numbers.Number (such as int, float, ...)
@@ -157,7 +160,10 @@ def number_regex(number):
         check50.run("./prog").stdout(check50.number_regex("7.0000"))
 
     """
-    return fr"(?<!\d){re.escape(str(number))}(?!(\.?\d))"
+    if number < 0:
+        return fr"{re.escape(str(number))}(?!(\.?\d))"
+
+    return fr"(?<![\d\-]){re.escape(str(number))}(?!(\.?\d))"
 
 
 class run:

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -211,6 +211,25 @@ class TestProcessStdout(Base):
         self.runpy()
         self.process.stdout(1.0)
 
+    def test_negative_number(self):
+        self.write("print(1)")
+        self.runpy()
+        with self.assertRaises(check50.Failure):
+            self.process.stdout(-1)
+
+        self.write("print(-1)")
+        self.runpy()
+        with self.assertRaises(check50.Failure):
+            self.process.stdout(1)
+
+        self.write("print('2-1')")
+        self.runpy()
+        self.process.stdout(-1)
+
+        self.write("print(-1)")
+        self.runpy()
+        self.process.stdout(-1)
+
 
 class TestProcessStdoutFile(Base):
     def setUp(self):

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -163,6 +163,55 @@ class TestProcessStdout(Base):
             self.process.stdout(".o.", regex=False)
         self.assertFalse(self.process.process.isalive())
 
+    def test_int(self):
+        self.write("print(123)")
+        self.runpy()
+        with self.assertRaises(check50.Failure):
+            self.process.stdout(1)
+
+        self.write("print(21)")
+        self.runpy()
+        with self.assertRaises(check50.Failure):
+            self.process.stdout(1)
+
+        self.write("print(1.0)")
+        self.runpy()
+        with self.assertRaises(check50.Failure):
+            self.process.stdout(1)
+
+        self.write("print('a1b')")
+        self.runpy()
+        self.process.stdout(1)
+
+        self.write("print(1)")
+        self.runpy()
+        self.process.stdout(1)
+
+    def test_float(self):
+        self.write("print(1.01)")
+        self.runpy()
+        with self.assertRaises(check50.Failure):
+            self.process.stdout(1.0)
+
+        self.write("print(21.0)")
+        self.runpy()
+        with self.assertRaises(check50.Failure):
+            self.process.stdout(1.0)
+
+        self.write("print(1)")
+        self.runpy()
+        with self.assertRaises(check50.Failure):
+            self.process.stdout(1.0)
+
+        self.write("print('a1.0b')")
+        self.runpy()
+        self.process.stdout(1.0)
+
+        self.write("print(1.0)")
+        self.runpy()
+        self.process.stdout(1.0)
+
+
 class TestProcessStdoutFile(Base):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
This adds int/float support to `run.stdout`. Whenever an int/float is passed as `output`, the following regex gets used to match that int or float exactly:

```Py
fr"(?<!\d){re.escape(str(output))}(?!\d|\.)"
```

<img src=https://user-images.githubusercontent.com/1257775/87186017-07ab6e80-c2eb-11ea-9ce5-d4502957b12b.png alt="drawing" width="400"/>

This is the transformation, but do note that str_output does not get overwritten if set by the user:

```
.stdout(1)   => .stdout(r"(?<!\d)1(?!\d|\.)", str_output=str(1), regex=True)
.stdout(1.0) => .stdout(r"(?<!\d)1.0(?!\d|\.)", str_output=str(1.0), regex=True)
```

The hope is that this PR can eliminate the need for something like this in checks when dealing with numbers:

https://github.com/cs50/problems/blob/d2bad69a5e842cd34a179e6b6e36b5f3de5027ac/cash/__init__.py#L78-L80


One final note, a float with additional trailing zeros does **not** match:

```Py
print("1.00")
run.stdout(1.0)
```

My thinking here is that most of the time you'd want an exact match, and trailing zeros can still be supported by passing the regex yourself. 

