### PR TITLE
Move regex to module

### DIFF
--- a/check50/__init__.py
+++ b/check50/__init__.py
@@ -38,16 +38,16 @@ from ._api import (
     exists,
     hash,
     include,
-    regex,
     run,
     log, _log,
     hidden,
-    Failure, Mismatch
+    Failure, Mismatch, Missing
 )
 
 
+from . import regex
 from .runner import check
 from pexpect import EOF
 
 __all__ = ["import_checks", "data", "exists", "hash", "include", "regex",
-           "run", "log", "Failure", "Mismatch", "check", "EOF"]
+           "run", "log", "Failure", "Mismatch", "Missing", "check", "EOF"]

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -12,7 +12,7 @@ import time
 import pexpect
 from pexpect.exceptions import EOF, TIMEOUT
 
-from . import internal
+from . import internal, regex
 
 _log = []
 internal.register.before_every(_log.clear)
@@ -136,34 +136,6 @@ def import_checks(path):
     sys.modules[dir.name] = mod
     return mod
 
-
-class regex:
-    @staticmethod
-    def decimal(number):
-        """
-        Create a regular expression to match the number exactly:
-            In case of a positive number:
-                (?<![\d\-])number(?!(\.?\d))
-            In case of a negative number:
-                number(?!(\.?\d))
-
-        (?<![\d\-]) = negative lookbehind, \
-            asserts that there are no digits and no - in front of the number.
-        (?!(\.?\d)) = negative lookahead, \
-            asserts that there are no digits and no additional . followed by digits after the number.
-
-        :param number: the number to match in the regex
-        :type number: any numbers.Number (such as int, float, ...)
-        :rtype: str
-
-        Example usage::
-
-            # Check that 7.0000 is printed with 5 significant figures
-            check50.run("./prog").stdout(check50.regex.decimal("7.0000"))
-
-        """
-        negative_lookbehind = fr"(?<![\d\-])" if number >= 0 else ""
-        return fr"{negative_lookbehind}{re.escape(str(number))}(?!(\.?\d))"
 
 
 class run:

--- a/check50/regex.py
+++ b/check50/regex.py
@@ -4,14 +4,19 @@ import re
 def decimal(number):
     """
     Create a regular expression to match the number exactly:
-        In case of a positive number:
-            (?<![\d\-])number(?!(\.?\d))
-        In case of a negative number:
-            number(?!(\.?\d))
 
-    (?<![\d\-]) = negative lookbehind, \
+    In case of a positive number::
+
+        (?<![\d\-])number(?!(\.?\d))
+
+    In case of a negative number::
+
+        number(?!(\.?\d))
+
+    :code:`(?<![\d\-])` = negative lookbehind, \
         asserts that there are no digits and no - in front of the number.
-    (?!(\.?\d)) = negative lookahead, \
+
+    :code:`(?!(\.?\d))` = negative lookahead, \
         asserts that there are no digits and no additional . followed by digits after the number.
 
     :param number: the number to match in the regex
@@ -26,4 +31,3 @@ def decimal(number):
     """
     negative_lookbehind = fr"(?<![\d\-])" if number >= 0 else ""
     return fr"{negative_lookbehind}{re.escape(str(number))}(?!(\.?\d))"
-

--- a/check50/regex.py
+++ b/check50/regex.py
@@ -1,0 +1,26 @@
+def decimal(number):
+    """
+    Create a regular expression to match the number exactly:
+        In case of a positive number:
+            (?<![\d\-])number(?!(\.?\d))
+        In case of a negative number:
+            number(?!(\.?\d))
+
+    (?<![\d\-]) = negative lookbehind, \
+        asserts that there are no digits and no - in front of the number.
+    (?!(\.?\d)) = negative lookahead, \
+        asserts that there are no digits and no additional . followed by digits after the number.
+
+    :param number: the number to match in the regex
+    :type number: any numbers.Number (such as int, float, ...)
+    :rtype: str
+
+    Example usage::
+
+        # Check that 7.0000 is printed with 5 significant figures
+        check50.run("./prog").stdout(check50.regex.decimal("7.0000"))
+
+    """
+    negative_lookbehind = fr"(?<![\d\-])" if number >= 0 else ""
+    return fr"{negative_lookbehind}{re.escape(str(number))}(?!(\.?\d))"
+

--- a/check50/regex.py
+++ b/check50/regex.py
@@ -1,3 +1,6 @@
+import re
+
+
 def decimal(number):
     """
     Create a regular expression to match the number exactly:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,17 +5,20 @@ API docs
 
 .. _check50:
 
+
 check50
 *******
 
 .. automodule:: check50
    :members:
 
+
 check50.c
 **********
 
 .. automodule:: check50.c
   :members:
+
 
 check50.flask
 ****************
@@ -28,6 +31,12 @@ check50.py
 ***********
 .. automodule:: check50.py
    :members:
+
+
+check50.regex
+**************
+.. automodule:: check50.regex
+  :members:
 
 
 check50.internal


### PR DESCRIPTION
A class that just contains static methods is essentially the same as a module so it seems kinda unidiomatic for `regex` to be a class. I get that it's a maybe a little weird to have a module with one function, but the whole reason for having regexes behind a namespace in the first place was for future-proofing.

Also, I noticed that `Missing` was not included in the import in __init__.py so I fixed that.