### PR TITLE
Replace bs4 dependency with beautifulsoup4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     message_extractors = {
         'check50': [('**.py', 'python', None),],
     },
-    install_requires=["attrs>=18", "bs4>=0", "pexpect>=4.6", "lib50>=2,<4", "pyyaml>=3.10", "requests>=2.19", "termcolor>=1.1", "jinja2>=2.10"],
+    install_requires=["attrs>=18", "beautifulsoup4>=0", "pexpect>=4.6", "lib50>=2,<4", "pyyaml>=3.10", "requests>=2.19", "termcolor>=1.1", "jinja2>=2.10"],
     extras_require = {
         "develop": ["sphinx", "sphinx-autobuild", "sphinx_rtd_theme"]
     },


### PR DESCRIPTION
The currently used [bs4](https://pypi.org/project/bs4/) is a dummy package with a transitive dependency to [beautifulsoup4](https://pypi.org/project/beautifulsoup4/). 

Resolves #190