### PR TITLE
Unpickleable attributes

### DIFF
--- a/check50/runner.py
+++ b/check50/runner.py
@@ -397,7 +397,7 @@ class run_check:
         # Create the checks module
         mod = importlib.util.module_from_spec(self.spec)
 
-        # Execute (effectively import) the checcks module
+        # Execute (effectively import) the checks module
         self.spec.loader.exec_module(mod)
 
         # Run just the check named self.check_name

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -391,7 +391,7 @@ class run_check:
 
 
     def __call__(self):
-        # Restore any attributes from the partent process
+        # Restore any attributes from the parent process
         self._set_attributes()
 
         # Create the checks module

--- a/tests/checks/unpicklable_attribute/.cs50.yaml
+++ b/tests/checks/unpicklable_attribute/.cs50.yaml
@@ -1,3 +1,1 @@
-check50:
-  files:
-    - !require foo.py
+check50: true

--- a/tests/checks/unpicklable_attribute/.cs50.yaml
+++ b/tests/checks/unpicklable_attribute/.cs50.yaml
@@ -1,0 +1,3 @@
+check50:
+  files:
+    - !require foo.py

--- a/tests/checks/unpicklable_attribute/__init__.py
+++ b/tests/checks/unpicklable_attribute/__init__.py
@@ -1,0 +1,9 @@
+import check50
+import sys
+
+# Set the excepthook to an unpicklable value, the run_check process will try to copy this
+sys.excepthook = lambda type, value, traceback: "bar"
+
+@check50.check()
+def foo():
+    """foo"""

--- a/tests/runner_tests.py
+++ b/tests/runner_tests.py
@@ -26,9 +26,6 @@ else:
 
 class TestMultiprocessingStartMethods(unittest.TestCase):
     def setUp(self):
-        self.working_directory = tempfile.TemporaryDirectory()
-        os.chdir(self.working_directory.name)
-
         # Keep track of get_start_method
         # This function gets monkey patched to ensure run_check is aware of the multiprocessing context, 
         # without needing to explicitely pass the context to run_check.
@@ -37,13 +34,9 @@ class TestMultiprocessingStartMethods(unittest.TestCase):
         self._get_start_method = multiprocessing.get_start_method()
 
     def tearDown(self):
-        self.working_directory.cleanup()
         multiprocessing.get_start_method = self._get_start_method
 
     def test_unpicklable_attribute(self):
-        with open("foo.py", "w") as f:
-            pass
-
         # Create the checks_spec and check_name needed for run_check
         checks_path = CHECKS_DIRECTORY / "unpicklable_attribute/__init__.py"
         check_name = "foo"

--- a/tests/runner_tests.py
+++ b/tests/runner_tests.py
@@ -1,0 +1,73 @@
+import check50
+import check50.runner
+
+import importlib
+import multiprocessing
+import os
+import pathlib
+import pexpect
+import sys
+import tempfile
+import unittest
+
+
+CHECKS_DIRECTORY = pathlib.Path(__file__).absolute().parent / "checks"
+CHECK50_SUPPORTED_START_METHODS = ("fork", "spawn")
+
+
+# Just test spawn under OS X due to a bug with "fork": https://bugs.python.org/issue33725
+if sys.platform == "darwin":
+    SUPPORTED_START_METHODS = ("spawn",)
+
+# Don't test forkserver under linux, serves no usecase for check50
+else:
+    SUPPORTED_START_METHODS = tuple(set(CHECK50_SUPPORTED_START_METHODS) & set(multiprocessing.get_all_start_methods()))
+
+
+class TestMultiprocessingStartMethods(unittest.TestCase):
+    def setUp(self):
+        self.working_directory = tempfile.TemporaryDirectory()
+        os.chdir(self.working_directory.name)
+
+        # Keep track of get_start_method
+        # This function gets monkey patched to ensure run_check is aware of the multiprocessing context, 
+        # without needing to explicitely pass the context to run_check.
+        # The same behavior can't be achieved by multiprocessing.set_start_method as that can only run once per program
+        # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+        self._get_start_method = multiprocessing.get_start_method()
+
+    def tearDown(self):
+        self.working_directory.cleanup()
+        multiprocessing.get_start_method = self._get_start_method
+
+    def test_unpicklable_attribute(self):
+        with open("foo.py", "w") as f:
+            pass
+
+        # Create the checks_spec and check_name needed for run_check
+        checks_path = CHECKS_DIRECTORY / "unpicklable_attribute/__init__.py"
+        check_name = "foo"
+        spec = importlib.util.spec_from_file_location("checks", checks_path)
+
+        # Execute the module once in the main process, as the Runner does too
+        # This will set sys.excepthook to an unpicklable lambda
+        check_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(check_module)
+
+        # For each available method
+        for start_method in SUPPORTED_START_METHODS:
+            
+            # Create a multiprocessing context for that method
+            ctx = multiprocessing.get_context(start_method)
+
+            # Monkey patch get_start_method() used by run_check to check for its method
+            multiprocessing.get_start_method = lambda: start_method
+
+            # Start and join each check process
+            p = ctx.Process(target=check50.runner.run_check(check_name, spec))
+            p.start()
+            p.join()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runner_tests.py
+++ b/tests/runner_tests.py
@@ -26,6 +26,9 @@ else:
 
 class TestMultiprocessingStartMethods(unittest.TestCase):
     def setUp(self):
+        self.working_directory = tempfile.TemporaryDirectory()
+        os.chdir(self.working_directory.name)
+
         # Keep track of get_start_method
         # This function gets monkey patched to ensure run_check is aware of the multiprocessing context, 
         # without needing to explicitely pass the context to run_check.
@@ -34,6 +37,7 @@ class TestMultiprocessingStartMethods(unittest.TestCase):
         self._get_start_method = multiprocessing.get_start_method()
 
     def tearDown(self):
+        self.working_directory.cleanup()
         multiprocessing.get_start_method = self._get_start_method
 
     def test_unpicklable_attribute(self):


### PR DESCRIPTION
Addresses: https://github.com/cs50/check50/issues/235 by allowing each of `check50.runner.run_check.CROSS_PROCESS_ATTRIBUTES` to be overwritten from within the checks by an unpicklable value. 