### PR TITLE
docs: fix broken json example.

### DIFF
--- a/docs/source/json_specification.rst
+++ b/docs/source/json_specification.rst
@@ -59,7 +59,7 @@ Produces the following:
                 },
                 "data": {},
                 "dependency": "compiles"
-            },
+            }
         ],
         "version": "3.0.0"
     }


### PR DESCRIPTION
The extra comma violates the json spec and means that the content is not readable in python (see https://github.com/pazz/grade50/issues/1).

Also see

```
jid < caesar.json
invalid json format: invalid character ']' looking for beginning of value
```