### PR TITLE
add nullcontext to _exceptions.py

### DIFF
--- a/check50/_exceptions.py
+++ b/check50/_exceptions.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import sys
 import traceback
@@ -6,6 +7,13 @@ import lib50
 import termcolor
 
 from . import internal, __version__
+
+
+@contextlib.contextmanager
+def nullcontext(entry_result=None):
+    """This is just contextlib.nullcontext but that function is only available in 3.7+."""
+    yield entry_result
+
 
 class Error(Exception):
     """Exception for internal check50 errors."""

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.2.2",
+    version="3.2.3",
     include_package_data=True
 )


### PR DESCRIPTION
json output exception handling uses nullcontext, and previously this gave a `NameError` whenever an exception occured with `-o json` 