### PR TITLE
raise FileNotFoundError in addition to IsADirectoryError in _copy

### DIFF
--- a/check50/_api.py
+++ b/check50/_api.py
@@ -515,7 +515,7 @@ def _copy(src, dst):
     """Copy src to dst, copying recursively if src is a directory."""
     try:
         shutil.copy(src, dst)
-    except IsADirectoryError:
+    except (FileNotFoundError, IsADirectoryError):
         if os.path.isdir(dst):
             dst = os.path.join(dst, os.path.basename(src))
         shutil.copytree(src, dst)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.3.3",
+    version="3.3.4",
     include_package_data=True
 )


### PR DESCRIPTION
Running `check50 --local cs50/problems/2021/fall/speller` on both macOS and Ubuntu 20.04 will run into `FileNotFoundError` exception.

And it seems shutil.copy() will raise `FileNotFoundError` exception, not `IsADirectoryError`:
[https://github.com/python/cpython/blame/e6d1aa1ac65b6908fdea2c70ec3aa8c4f1dffcb5/Lib/shutil.py#L284](https://github.com/python/cpython/blame/e6d1aa1ac65b6908fdea2c70ec3aa8c4f1dffcb5/Lib/shutil.py#L284)

Perhaps we should catch both exceptions for now.