### PR TITLE
Show html path within wsl

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -19,7 +19,6 @@ import time
 
 import attr
 import lib50
-from matplotlib.pyplot import stem
 import requests
 import termcolor
 

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -7,6 +7,7 @@ import inspect
 import itertools
 import logging
 import os
+import platform
 import site
 from pathlib import Path
 import shutil
@@ -18,6 +19,7 @@ import time
 
 import attr
 import lib50
+from matplotlib.pyplot import stem
 import requests
 import termcolor
 
@@ -398,7 +400,13 @@ def main():
                         html = renderer.to_html(**results)
                         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".html") as html_file:
                             html_file.write(html)
-                        url = f"file://{html_file.name}"
+
+                        if "microsoft-standard" in platform.uname().release:
+                            stream = os.popen(f"wslpath -w {html_file.name}")
+                            wsl_path = stream.read().strip()
+                            url = f"file://{wsl_path}"
+                        else:
+                            url = f"file://{html_file.name}"
                     else:
                         url = f"https://submit.cs50.io/check50/{tag_hash}"
 

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -401,7 +401,7 @@ def main():
                             html_file.write(html)
 
                         if "microsoft-standard" in platform.uname().release:
-                            stream = os.popen(f"wslpath -w {html_file.name}")
+                            stream = os.popen(f"wslpath -m {html_file.name}")
                             wsl_path = stream.read().strip()
                             url = f"file://{wsl_path}"
                         else:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         "console_scripts": ["check50=check50.__main__:main"]
     },
     url="https://github.com/cs50/check50",
-    version="3.3.6",
+    version="3.3.7",
     include_package_data=True
 )


### PR DESCRIPTION
Closes #275 
Checking if we're running wsl using https://www.scivision.dev/python-detect-wsl/
Then converting the path within Ubuntu to a windows path with `wslpath -w`.


Tested with `check50 cs50/problems/2021/fall/hello --local` on macOS 12.2.1 with python 3.9.10 and WSL Ubuntu 20.04 with python 3.8.10

WSL result:
```To see the results in your browser go to file:///wsl.localhost/Ubuntu/tmp/tmpveuwk16x.html```

macOS result:
```To see the results in your browser go to file:///var/folders/j9/6b_9k8xs3pzcf8pxp6g08twh0000gn/T/tmp3iev6si6.html```