### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,6 +43,12 @@ To install check50 under Linux / OS X:
 
     pip install check50
 
+Under Apple Silicon/ARM devices:
+
+.. code-block:: bash
+
+    pip install check50 --compile
+
 Under Windows, please |install_windows_sub|. Then install check50 within the subsystem.
 
 .. |install_windows_sub| raw:: html


### PR DESCRIPTION
- [x] *Add installation code snippet for ARM devices

# Why
check50's dependencies have lot of problems on Apple Silicon/ARM devices for now(I have tested on several devices).
I've added `--compile` to ensure all dependencies will be compiled on user's system.