### PR TITLE
Windows Support for `check50`

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -345,6 +345,12 @@ def main():
         with lib50.ProgressBar("Checking") if "ansi" in args.output else nullcontext():
             # If developing, assume slug is a path to check_dir
             if args.dev:
+                # On Windows, the path is sometimes quoted. Resolving it as it is
+                # will give errors. Un-quote the path to a normal path string.
+                if os.name == "nt" and '"' in internal.slug:
+                    import oslex
+                    internal.slug = oslex.split(internal.slug)[0]
+
                 internal.check_dir = Path(internal.slug).expanduser().resolve()
                 if not internal.check_dir.is_dir():
                     raise _exceptions.Error(_("{} is not a directory").format(internal.check_dir))

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -10,6 +10,7 @@ import sys
 import time
 
 import pexpect
+from pexpect.popen_spawn import PopenSpawn
 from pexpect.exceptions import EOF, TIMEOUT
 
 from . import internal, regex
@@ -173,6 +174,8 @@ class run:
             python_path = shutil.which("python")
             command = oslex.quote(python_path) + command[len("python3"):]
 
+        self.process = PopenSpawn(command, encoding="utf-8", env=full_env)
+
     def stdin(self, line, str_line=None, prompt=True, timeout=3):
         """
         Send line to stdin, optionally expect a prompt.
@@ -203,6 +206,11 @@ class run:
             try:
                 self.process.expect(".+", timeout=timeout)
             except (TIMEOUT, EOF):
+                # This terminates the process whose prompt is expected.
+                # As there would be a timeout or EOF, the testing should
+                # be stopped and marked as not complete.
+                self.kill()
+
                 raise Failure(_("expected prompt for input, found none"))
             except UnicodeDecodeError:
                 raise Failure(_("output not valid ASCII text"))
@@ -289,8 +297,14 @@ class run:
             result = self.process.before + self.process.buffer
             if self.process.after != EOF:
                 result += self.process.after
+
             raise Mismatch(str_output, result.replace("\r\n", "\n"))
         except TIMEOUT:
+            # This terminates the process whose output is to be matched.
+            # As there is a timeout, the testing should be stopped and
+            # marked as not complete.
+            self.kill()
+
             if show_timeout:
                 raise Missing(str_output, self.process.before,
                               help=_("check50 waited {} seconds for the output of the program").format(timeout))
@@ -364,7 +378,9 @@ class run:
 
         Child will first be sent a ``SIGHUP``, followed by a ``SIGINT`` and
         finally a ``SIGKILL`` if it ignores the first two."""
-        self.process.close(force=True)
+        if self.isalive():
+            self.process.proc.kill()
+            self.process.proc.wait()
         return self
 
     def _wait(self, timeout=5):
@@ -380,8 +396,11 @@ class run:
         if self.process.signalstatus == signal.SIGSEGV:
             raise Failure(_("failed to execute program due to segmentation fault"))
 
-        self.exitcode = self.process.exitstatus
+        self.exitcode = self.process.proc.returncode
         return self
+
+    def isalive(self):
+        return self.process.proc.poll() == None
 
 
 class Failure(Exception):

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -3,7 +3,7 @@ import functools
 import numbers
 import os
 import re
-import shlex
+import oslex
 import shutil
 import signal
 import sys
@@ -164,7 +164,12 @@ class run:
         # Workaround for OSX pexpect bug http://pexpect.readthedocs.io/en/stable/commonissues.html#truncated-output-just-before-child-exits
         # Workaround from https://github.com/pexpect/pexpect/issues/373
         command = "bash -c {}".format(shlex.quote(command))
-        self.process = pexpect.spawn(command, encoding="utf-8", echo=False, env=full_env)
+        if os.name == "nt" and command.startswith("python3"):
+            # Special logic for quoting Python interpreter path
+            # for Windows.
+            import oslex
+            python_path = shutil.which("python")
+            command = oslex.quote(python_path) + command[len("python3"):]
 
     def stdin(self, line, str_line=None, prompt=True, timeout=3):
         """

--- a/check50/_api.py
+++ b/check50/_api.py
@@ -163,7 +163,9 @@ class run:
 
         # Workaround for OSX pexpect bug http://pexpect.readthedocs.io/en/stable/commonissues.html#truncated-output-just-before-child-exits
         # Workaround from https://github.com/pexpect/pexpect/issues/373
-        command = "bash -c {}".format(shlex.quote(command))
+        if shutil.which("bash"):
+            command = "bash -c {}".format(command)
+
         if os.name == "nt" and command.startswith("python3"):
             # Special logic for quoting Python interpreter path
             # for Windows.

--- a/check50/_simple.py
+++ b/check50/_simple.py
@@ -59,7 +59,7 @@ def _compile_check(name, check):
     if check_name[0].isdigit():
         check_name = f"_{check_name}"
 
-    if not re.match("\w+", check_name):
+    if not re.match(r"\w+", check_name):
         raise CompileError(
                 _("{} is not a valid name for a check; check names should consist only of alphanumeric characters, underscores, and spaces").format(name))
 
@@ -79,6 +79,16 @@ def _compile_check(name, check):
         for command_name in COMMANDS:
             if command_name in run:
                 line.append(COMMANDS[command_name](run[command_name]))
+
+        # In order for every check to completely leave their temporary working
+        # directories set up in `check50.run`(which uses PopenSpawn) before
+        # the entire script completes, there must be an additional `.exit()`
+        # at the end of the check50 commands chain.
+        # This will ensure that the calling context will not be exited until
+        # the child processes complete their cleanup.
+        if run["exit"] == None:
+            line.append(".exit()")
+
         out.append("".join(line))
 
     return "\n".join(out)

--- a/check50/c.py
+++ b/check50/c.py
@@ -56,6 +56,7 @@ def compile(*files, exe_name=None, cc=CC, max_log_lines=50, **cflags):
     out_flag = f" -o {exe_name} " if exe_name is not None else " "
 
     process = run(f"{cc} {files}{out_flag}{flags}")
+    process.exit(timeout=30)
 
     # Strip out ANSI codes
     stdout = re.sub(r"\x1B\[[0-?]*[ -/]*[@-~]", "",  process.stdout())

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -312,11 +312,11 @@ class CheckRunner:
 
 
     def __exit__(self, type, value, tb):
-        # Destroy the temporary directory for the checks
-        self._working_area_manager.__exit__(type, value, tb)
-
         # cd back to the directory check50 was called from
         self._cd_manager.__exit__(type, value, tb)
+
+        # Destroy the temporary directory for the checks
+        self._working_area_manager.__exit__(type, value, tb)
 
 
 class run_check:

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -72,16 +72,17 @@ def _timeout(seconds):
             print("do_stuff timed out")
     """
 
+    from threading import Timer
+
     def _handle_timeout(*args):
         raise Timeout(seconds)
 
-    signal.signal(signal.SIGALRM, _handle_timeout)
-    signal.alarm(seconds)
+    timer = Timer(seconds, _handle_timeout)
     try:
+        timer.start()
         yield
     finally:
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, signal.SIG_DFL)
+        timer.cancel()
 
 
 def check(dependency=None, timeout=60, max_log_lines=100):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-if __import__("os").name == "nt":
-    raise RuntimeError("check50 does not support Windows directly. Instead, you should install the Windows Subsystem for Linux (https://docs.microsoft.com/en-us/windows/wsl/install-win10) and then install check50 within that.")
-
 from setuptools import setup
 
 setup(

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -21,7 +21,7 @@ class Base(unittest.TestCase):
         self.process = None
 
     def tearDown(self):
-        if self.process and self.process.process.isalive():
+        if self.process and self.process.isalive():
             self.process.kill()
         os.chdir(self.current_working_directory)
         self.working_directory.cleanup()
@@ -99,9 +99,9 @@ class TestRun(Base):
 class TestProcessKill(Base):
     def test_kill(self):
         self.runpy()
-        self.assertTrue(self.process.process.isalive())
+        self.assertTrue(self.process.isalive())
         self.process.kill()
-        self.assertFalse(self.process.process.isalive())
+        self.assertFalse(self.process.isalive())
 
 class TestProcessStdin(Base):
     def test_expect_prompt_no_prompt(self):
@@ -114,26 +114,26 @@ class TestProcessStdin(Base):
         self.write("x = input('foo')")
         self.runpy()
         self.process.stdin("bar")
-        self.assertTrue(self.process.process.isalive())
+        self.assertTrue(self.process.isalive())
 
     def test_no_prompt(self):
         self.write("x = input()\n")
         self.runpy()
         self.process.stdin("bar", prompt=False)
-        self.assertTrue(self.process.process.isalive())
+        self.assertTrue(self.process.isalive())
 
 class TestProcessStdout(Base):
     def test_no_out(self):
         self.runpy()
         out = self.process.stdout(timeout=1)
         self.assertEqual(out, "")
-        self.assertFalse(self.process.process.isalive())
+        self.assertFalse(self.process.isalive())
 
         self.write("print('foo')")
         self.runpy()
         out = self.process.stdout()
         self.assertEqual(out, "foo\n")
-        self.assertFalse(self.process.process.isalive())
+        self.assertFalse(self.process.isalive())
 
     def test_out(self):
         self.runpy()
@@ -282,7 +282,7 @@ class TestProcessKill(Base):
     def test_kill(self):
         self.runpy()
         self.process.kill()
-        self.assertFalse(self.process.process.isalive())
+        self.assertFalse(self.process.isalive())
 
 class TestProcessReject(Base):
     def test_reject(self):

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -11,6 +11,7 @@ import check50.internal
 
 class Base(unittest.TestCase):
     def setUp(self):
+        self.current_working_directory = os.getcwd()
         self.working_directory = tempfile.TemporaryDirectory()
         os.chdir(self.working_directory.name)
 
@@ -22,6 +23,7 @@ class Base(unittest.TestCase):
     def tearDown(self):
         if self.process and self.process.process.isalive():
             self.process.kill()
+        os.chdir(self.current_working_directory)
         self.working_directory.cleanup()
 
     def write(self, source):

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -31,7 +31,7 @@ class Base(unittest.TestCase):
             f.write(source)
 
     def runpy(self):
-        self.process = check50.run(f"python3 ./{self.filename}")
+        self.process = check50.run(f"python3 {self.filename}")
 
 class TestInclude(Base):
     def setUp(self):
@@ -93,7 +93,7 @@ class TestImportChecks(Base):
 
 class TestRun(Base):
     def test_returns_process(self):
-        self.process = check50.run("python3 ./{self.filename}")
+        self.process = check50.run(f"python3 {self.filename}")
 
 
 class TestProcessKill(Base):
@@ -109,6 +109,10 @@ class TestProcessStdin(Base):
         self.runpy()
         with self.assertRaises(check50.Failure):
             self.process.stdin("bar")
+        # The previous `.stdin("bar")` call will not actually send
+        # any input as an exception is raised. Hence we
+        self.process.stdin("just exit the script when test is over", prompt=False)
+        self.process.exit()
 
     def test_expect_prompt(self):
         self.write("x = input('foo')")
@@ -117,7 +121,9 @@ class TestProcessStdin(Base):
         self.assertTrue(self.process.isalive())
 
     def test_no_prompt(self):
-        self.write("x = input()\n")
+        # `time.sleep` will ensure that the script still runs
+        # after the input is sent to the prompt.
+        self.write("x = input()\nimport time\ntime.sleep(3)\n")
         self.runpy()
         self.process.stdin("bar", prompt=False)
         self.assertTrue(self.process.isalive())
@@ -139,7 +145,9 @@ class TestProcessStdout(Base):
         self.runpy()
         with self.assertRaises(check50.Failure):
             self.process.stdout("foo")
-        self.assertFalse(self.process.process.isalive())
+        # Wait until exit. No need to check if process is dead.
+        # Timeout will fire after 5 seconds if necessary.
+        self.process.exit()
 
         self.write("print('foo')")
         self.runpy()
@@ -163,7 +171,9 @@ class TestProcessStdout(Base):
         self.runpy()
         with self.assertRaises(check50.Failure):
             self.process.stdout(".o.", regex=False)
-        self.assertFalse(self.process.process.isalive())
+        # Wait until exit. No need to check if process is dead.
+        # Timeout will fire after 5 seconds if necessary.
+        self.process.exit()
 
     def test_int(self):
         self.write("print(123)")
@@ -266,7 +276,9 @@ class TestProcessExit(Base):
         self.runpy()
         with self.assertRaises(check50.Failure):
             self.process.exit(0)
-        self.process.kill()
+        # Wait until exit. No need to check if process is dead.
+        # Timeout will fire after 5 seconds if necessary.
+        self.process.exit()
 
         self.write("sys.exit(1)")
         self.runpy()

--- a/tests/c_tests.py
+++ b/tests/c_tests.py
@@ -21,10 +21,12 @@ class Base(unittest.TestCase):
         if not VALGRIND_INSTALLED:
             raise unittest.SkipTest("valgrind not installed")
 
+        self.current_working_directory = os.getcwd()
         self.working_directory = tempfile.TemporaryDirectory()
         os.chdir(self.working_directory.name)
 
     def tearDown(self):
+        os.chdir(self.current_working_directory)
         self.working_directory.cleanup()
 
 class TestCompile(Base):

--- a/tests/check50_tests.py
+++ b/tests/check50_tests.py
@@ -11,10 +11,12 @@ CHECKS_DIRECTORY = pathlib.Path(__file__).absolute().parent / "checks"
 
 class Base(unittest.TestCase):
     def setUp(self):
+        self.current_working_directory = os.getcwd()
         self.working_directory = tempfile.TemporaryDirectory()
         os.chdir(self.working_directory.name)
 
     def tearDown(self):
+        os.chdir(self.current_working_directory)
         self.working_directory.cleanup()
 
 

--- a/tests/check50_tests.py
+++ b/tests/check50_tests.py
@@ -1,11 +1,13 @@
 import unittest
 import json
 import pexpect
+from pexpect.popen_spawn import PopenSpawn
 import pathlib
 import shutil
 import subprocess
 import os
 import tempfile
+import oslex
 
 CHECKS_DIRECTORY = pathlib.Path(__file__).absolute().parent / "checks"
 
@@ -36,171 +38,171 @@ class SimpleBase(Base):
 
 class TestExists(Base):
     def test_no_file(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/exists")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "exists"))}")
         process.expect_exact(":(")
         process.expect_exact("foo.py exists")
         process.expect_exact("foo.py not found")
-        process.close(force=True)
+        process.wait()
 
     def test_with_file(self):
         open("foo.py", "w").close()
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/exists")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "exists"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
-        process.close(force=True)
+        process.wait()
 
 
 class TestExitPy(Base):
     def test_no_file(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/exit_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "exit_py"))}")
         process.expect_exact(":(")
         process.expect_exact("foo.py exists")
         process.expect_exact("foo.py not found")
         process.expect_exact(":|")
         process.expect_exact("foo.py exits properly")
         process.expect_exact("can't check until a frown turns upside down")
-        process.close(force=True)
+        process.wait()
 
     def test_with_correct_file(self):
         open("foo.py", "w").close()
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/exit_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "exit_py"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact(":)")
         process.expect_exact("foo.py exits properly")
-        process.close(force=True)
+        process.wait()
 
     def test_with_incorrect_file(self):
         with open("foo.py", "w") as f:
             f.write("from sys import exit\nexit(1)")
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/exit_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "exit_py"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact(":(")
         process.expect_exact("foo.py exits properly")
         process.expect_exact("expected exit code 0, not 1")
-        process.close(force=True)
+        process.wait()
 
 
 class TestStdoutPy(Base):
     def test_no_file(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdout_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdout_py"))}")
         process.expect_exact(":(")
         process.expect_exact("foo.py exists")
         process.expect_exact("foo.py not found")
         process.expect_exact(":|")
         process.expect_exact("prints hello")
         process.expect_exact("can't check until a frown turns upside down")
-        process.close(force=True)
+        process.wait()
 
     def test_with_empty_file(self):
         open("foo.py", "w").close()
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdout_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdout_py"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact(":(")
         process.expect_exact("prints hello")
         process.expect_exact("expected \"hello\", not \"\"")
-        process.close(force=True)
+        process.wait()
 
 
     def test_with_correct_file(self):
         with open("foo.py", "w") as f:
             f.write('print("hello")')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdout_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdout_py"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact(":)")
         process.expect_exact("prints hello")
-        process.close(force=True)
+        process.wait()
 
 class TestStdoutTimeout(Base):
     def test_stdout_timeout(self):
         with open("foo.py", "w") as f:
             f.write("while True: pass")
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdout_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdout_py"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact(":(")
         process.expect_exact("check50 waited 1 seconds for the output of the program")
-        process.close(force=True)
+        process.wait()
 
 class TestStdinPy(Base):
     def test_no_file(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_py"))}")
         process.expect_exact(":(")
         process.expect_exact("foo.py exists")
         process.expect_exact("foo.py not found")
         process.expect_exact(":|")
         process.expect_exact("prints hello name")
         process.expect_exact("can't check until a frown turns upside down")
-        process.close(force=True)
+        process.wait()
 
     def test_with_empty_file(self):
         open("foo.py", "w").close()
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_py"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact(":(")
         process.expect_exact("prints hello name")
         process.expect_exact("expected \"hello bar\", not \"\"")
-        process.close(force=True)
+        process.wait()
 
     def test_with_correct_file(self):
         with open("foo.py", "w") as f:
             f.write('name = input()\nprint("hello", name)')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_py"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact(":)")
         process.expect_exact("prints hello name")
-        process.close(force=True)
+        process.wait()
 
 
 class TestStdinPromptPy(Base):
     def test_no_file(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_prompt_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_prompt_py"))}")
         process.expect_exact(":(")
         process.expect_exact("prints hello name")
-        process.close(force=True)
+        process.wait()
 
     def test_with_empty_file(self):
         open("foo.py", "w").close()
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_prompt_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_prompt_py"))}")
         process.expect_exact(":(")
         process.expect_exact("prints hello name")
         process.expect_exact("expected prompt for input, found none")
-        process.close(force=True)
+        process.wait()
 
     def test_with_incorrect_file(self):
         with open("foo.py", "w") as f:
             f.write('name = input()\nprint("hello", name)')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_prompt_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_prompt_py"))}")
         process.expect_exact(":(")
         process.expect_exact("prints hello name")
         process.expect_exact("expected prompt for input, found none")
-        process.close(force=True)
+        process.wait()
 
     def test_with_correct_file(self):
         with open("foo.py", "w") as f:
             f.write('name = input("prompt")\nprint("hello", name)')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_prompt_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_prompt_py"))}")
         process.expect_exact(":)")
         process.expect_exact("prints hello name")
-        process.close(force=True)
+        process.wait()
 
 
 class TestStdinMultiline(Base):
     def test_no_file(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_multiline")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_multiline"))}")
         process.expect_exact(":(")
         process.expect_exact("prints hello name (non chaining)")
         process.expect_exact(":(")
@@ -209,12 +211,12 @@ class TestStdinMultiline(Base):
         process.expect_exact("prints hello name (chaining)")
         process.expect_exact(":(")
         process.expect_exact("prints hello name (chaining) (order)")
-        process.close(force=True)
+        process.wait()
 
     def test_with_empty_file(self):
         open("foo.py", "w").close()
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_multiline")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_multiline"))}")
         process.expect_exact(":(")
         process.expect_exact("prints hello name (non chaining)")
         process.expect_exact(":(")
@@ -223,13 +225,13 @@ class TestStdinMultiline(Base):
         process.expect_exact("prints hello name (chaining)")
         process.expect_exact(":(")
         process.expect_exact("prints hello name (chaining) (order)")
-        process.close(force=True)
+        process.wait()
 
     def test_with_incorrect_file(self):
         with open("foo.py", "w") as f:
             f.write('name = input()\nprint("hello", name)')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_multiline")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_multiline"))}")
         process.expect_exact(":(")
         process.expect_exact("prints hello name (non chaining)")
         process.expect_exact(":(")
@@ -239,13 +241,13 @@ class TestStdinMultiline(Base):
         process.expect_exact("prints hello name (chaining)")
         process.expect_exact(":(")
         process.expect_exact("prints hello name (chaining) (order)")
-        process.close(force=True)
+        process.wait()
 
     def test_with_correct_file(self):
         with open("foo.py", "w") as f:
             f.write('for _ in range(2):\n    name = input("prompt")\n    print("hello", name)')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_multiline")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_multiline"))}")
         process.expect_exact(":)")
         process.expect_exact("prints hello name (non chaining)")
         process.expect_exact(":)")
@@ -254,14 +256,14 @@ class TestStdinMultiline(Base):
         process.expect_exact("prints hello name (chaining)")
         process.expect_exact(":)")
         process.expect_exact("prints hello name (chaining) (order)")
-        process.close(force=True)
+        process.wait()
 
 class TestStdinHumanReadable(Base):
     def test_without_human_readable_string(self):
         with open("foo.py", "w") as f:
             f.write('name = input()\nprint("hello", name)')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_py"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact("checking that foo.py exists...")
@@ -270,13 +272,13 @@ class TestStdinHumanReadable(Base):
         process.expect_exact("running python3 foo.py...")
         process.expect_exact("sending input bar...")
         process.expect_exact("checking for output \"hello bar\"...")
-        process.close(force=True)
+        process.wait()
 
     def test_with_human_readable_string(self):
         with open("foo.py", "w") as f:
             f.write('name = input("prompt")')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/stdin_human_readable_py")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "stdin_human_readable_py"))}")
         process.expect_exact(":)")
         process.expect_exact("foo.py exists")
         process.expect_exact("checking that foo.py exists...")
@@ -284,52 +286,52 @@ class TestStdinHumanReadable(Base):
         process.expect_exact("takes input")
         process.expect_exact("running python3 foo.py...")
         process.expect_exact("sending input bbb...")
-        process.close(force=True)
+        process.wait()
 
 
 class TestCompileExit(SimpleBase):
     compiled_loc = CHECKS_DIRECTORY / "compile_exit" / "__init__.py"
 
     def test_no_file(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/compile_exit")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "compile_exit"))}")
         process.expect_exact(":(")
         process.expect_exact("exit")
-        process.close(force=True)
+        process.wait()
 
     def test_with_correct_file(self):
         open("foo.py", "w").close()
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/compile_exit")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "compile_exit"))}")
         process.expect_exact(":)")
         process.expect_exact("exit")
-        process.close(force=True)
+        process.wait()
 
 
 class TestCompileStd(SimpleBase):
     compiled_loc = CHECKS_DIRECTORY / "compile_std" / "__init__.py"
 
     def test_no_file(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/compile_std")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "compile_std"))}")
         process.expect_exact(":(")
         process.expect_exact("std")
-        process.close(force=True)
+        process.wait()
 
     def test_with_incorrect_stdout(self):
         with open("foo.py", "w") as f:
             f.write('name = input()\nprint("hello", name)')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/compile_std")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "compile_std"))}")
         process.expect_exact(":)")
         process.expect_exact("std")
-        process.close(force=True)
+        process.wait()
 
     def test_correct(self):
         with open("foo.py", "w") as f:
             f.write('name = input()\nprint(name)')
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/compile_std")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "compile_std"))}")
         process.expect_exact(":)")
         process.expect_exact("std")
-        process.close(force=True)
+        process.wait()
 
 
 class TestCompilePrompt(SimpleBase):
@@ -339,44 +341,45 @@ class TestCompilePrompt(SimpleBase):
         with open("foo.py", "w"), open(self.compiled_loc, "w"):
             pass
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/compile_prompt")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "compile_prompt"))}")
         process.expect_exact("check50 will compile the YAML checks to __init__.py")
-        process.close(force=True)
+        process.sendline("n")
+        process.wait()
 
 
 class TestOutputModes(Base):
     def test_json_output(self):
-        pexpect.run(f"check50 --dev -o json --output-file foo.json {CHECKS_DIRECTORY}/output")
+        PopenSpawn(f"check50 --dev -o json --output-file foo.json {oslex.quote(str(CHECKS_DIRECTORY / "output"))}").wait()
         with open("foo.json", "r") as f:
             json_out = json.load(f)
             self.assertEqual(json_out["results"][0]["name"], "exists")
 
     def test_ansi_output(self):
-        process = pexpect.spawn(f"check50 --dev -o ansi -- {CHECKS_DIRECTORY}/output")
+        process = PopenSpawn(f"check50 --dev -o ansi -- {oslex.quote(str(CHECKS_DIRECTORY / "output"))}")
         process.expect_exact(":(")
-        process.close(force=True)
+        process.wait()
 
     def test_html_output(self):
-        process = pexpect.spawn(f"check50 --dev -o html -- {CHECKS_DIRECTORY}/output")
+        process = PopenSpawn(f"check50 --dev -o html -- {oslex.quote(str(CHECKS_DIRECTORY / "output"))}")
         process.expect_exact("file://")
-        process.close(force=True)
+        process.wait()
 
     def test_multiple_outputs(self):
-        process = pexpect.spawn(f"check50 --dev -o html ansi -- {CHECKS_DIRECTORY}/output")
+        process = PopenSpawn(f"check50 --dev -o html ansi -- {oslex.quote(str(CHECKS_DIRECTORY / "output"))}")
         process.expect_exact("file://")
         process.expect_exact(":(")
-        process.close(force=True)
+        process.wait()
 
     def test_default(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/output")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "output"))}")
         process.expect_exact(":(")
         process.expect_exact("file://")
-        process.close(force=True)
+        process.wait()
 
 
 class TestHiddenCheck(Base):
     def test_hidden_check(self):
-        pexpect.run(f"check50 --dev -o json --output-file foo.json {CHECKS_DIRECTORY}/hidden")
+        PopenSpawn(f"check50 --dev -o json --output-file foo.json {oslex.quote(str(CHECKS_DIRECTORY / "hidden"))}").wait()
         expected = [{'name': 'check', 'description': "check", 'passed': False, 'log': [], 'cause': {"rationale": "foo", "help": None}, 'data': {}, 'dependency': None}]
         with open("foo.json", "r") as f:
             self.assertEqual(json.load(f)["results"], expected)
@@ -384,7 +387,7 @@ class TestHiddenCheck(Base):
 
 class TestPayloadCheck(Base):
     def test_payload_check(self):
-        pexpect.run(f"check50 --dev -o json --output-file foo.json {CHECKS_DIRECTORY}/payload")
+        PopenSpawn(f"check50 --dev -o json --output-file foo.json {oslex.quote(str(CHECKS_DIRECTORY / "payload"))}").wait()
         with open("foo.json", "r") as f:
             error = json.load(f)["error"]
         self.assertEqual(error["type"], "MissingFilesError")
@@ -396,7 +399,7 @@ class TestTarget(Base):
     def test_target(self):
         open("foo.py", "w").close()
 
-        pexpect.run(f"check50 --dev -o json --output-file foo.json --target exists1 -- {CHECKS_DIRECTORY}/target")
+        PopenSpawn(f"check50 --dev -o json --output-file foo.json --target exists1 -- {oslex.quote(str(CHECKS_DIRECTORY / "target"))}").wait()
         with open("foo.json", "r") as f:
             output = json.load(f)
 
@@ -407,7 +410,7 @@ class TestTarget(Base):
     def test_target_with_dependency(self):
         open("foo.py", "w").close()
 
-        pexpect.run(f"check50 --dev -o json --output-file foo.json --target exists3 -- {CHECKS_DIRECTORY}/target")
+        PopenSpawn(f"check50 --dev -o json --output-file foo.json --target exists3 -- {oslex.quote(str(CHECKS_DIRECTORY / "target"))}").wait()
         with open("foo.json", "r") as f:
             output = json.load(f)
 
@@ -419,7 +422,7 @@ class TestTarget(Base):
     def test_two_targets(self):
         open("foo.py", "w").close()
 
-        pexpect.run(f"check50 --dev -o json --output-file foo.json --target exists1 exists2 -- {CHECKS_DIRECTORY}/target")
+        PopenSpawn(f"check50 --dev -o json --output-file foo.json --target exists1 exists2 -- {oslex.quote(str(CHECKS_DIRECTORY / "target"))}").wait()
         with open("foo.json", "r") as f:
             output = json.load(f)
 
@@ -431,7 +434,7 @@ class TestTarget(Base):
     def test_target_failing_dependency(self):
         open("foo.py", "w").close()
 
-        pexpect.run(f"check50 --dev -o json --output-file foo.json --target exists5 -- {CHECKS_DIRECTORY}/target")
+        PopenSpawn(f"check50 --dev -o json --output-file foo.json --target exists5 -- {oslex.quote(str(CHECKS_DIRECTORY / "target"))}").wait()
         with open("foo.json", "r") as f:
             output = json.load(f)
 
@@ -443,17 +446,20 @@ class TestTarget(Base):
 class TestRemoteException(Base):
     def test_no_traceback(self):
         # Check that bar (part of traceback) is not shown
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/remote_exception_no_traceback")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "remote_exception_no_traceback"))}")
         self.assertRaises(pexpect.exceptions.EOF, lambda: process.expect("bar"))
+        process.wait()
 
         # Check that foo (the message) is shown
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/remote_exception_no_traceback")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "remote_exception_no_traceback"))}")
         process.expect("foo")
+        process.wait()
 
     def test_traceback(self):
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/remote_exception_traceback")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "remote_exception_traceback"))}")
         process.expect("bar")
         process.expect("foo")
+        process.wait()
 
 
 class TestInternalDirectories(Base):
@@ -461,35 +467,33 @@ class TestInternalDirectories(Base):
         with open("foo.py", "w") as f:
             f.write(os.getcwd())
 
-        process = pexpect.spawn(f"check50 --dev {CHECKS_DIRECTORY}/internal_directories")
+        process = PopenSpawn(f"check50 --dev {oslex.quote(str(CHECKS_DIRECTORY / "internal_directories"))}")
         process.expect_exact(":)")
+        process.wait()
 
 
 class TestExitCode(Base):
     def test_error_result_exit_code(self):
         process = subprocess.run(
-            ["check50", "--dev", f"{CHECKS_DIRECTORY}/exit_code/error"],
+            ["check50", "--dev", f"{oslex.quote(str(CHECKS_DIRECTORY / "exit_code" / "error"))}"],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=2
+            stderr=subprocess.DEVNULL
         )
         self.assertEqual(process.returncode, 1)
 
     def test_failed_check_exit_code(self):
         process = subprocess.run(
-            ["check50", "--dev", f"{CHECKS_DIRECTORY}/exit_code/failure"],
+            ["check50", "--dev", f"{oslex.quote(str(CHECKS_DIRECTORY / "exit_code" / "failure"))}"],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=2
+            stderr=subprocess.DEVNULL
         )
         self.assertEqual(process.returncode, 1)
 
     def test_successful_exit(self):
         process = subprocess.run(
-            ["check50", "--dev", f"{CHECKS_DIRECTORY}/exit_code/success"],
+            ["check50", "--dev", f"{oslex.quote(str(CHECKS_DIRECTORY / "exit_code" / "success"))}"],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=2
+            stderr=subprocess.DEVNULL
         )
         self.assertEqual(process.returncode, 0)
 

--- a/tests/checks/stdin_human_readable_py/check.py
+++ b/tests/checks/stdin_human_readable_py/check.py
@@ -8,4 +8,4 @@ def exists():
 @check50.check(exists)
 def takes_input():
     """takes input"""
-    check50.run("python3 foo.py").stdin("aaa", prompt=False, str_line="bbb")
+    check50.run("python3 foo.py").stdin("aaa", prompt=False, str_line="bbb").exit()

--- a/tests/checks/stdin_multiline/check.py
+++ b/tests/checks/stdin_multiline/check.py
@@ -3,19 +3,19 @@ import check50
 @check50.check()
 def prints_hello_name_non_chaining():
     """prints hello name (non chaining)"""
-    check50.run("python3 foo.py").stdin("bar\nbaz", prompt=False).stdout("hello bar").stdout("hello baz")
+    check50.run("python3 foo.py").stdin("bar\nbaz", prompt=False).stdout("hello bar").stdout("hello baz").exit()
 
 @check50.check()
 def prints_hello_name_non_chaining_prompt():
     """prints hello name (non chaining) (prompt)"""
-    check50.run("python3 foo.py").stdin("bar\nbaz").stdout("hello bar").stdout("hello baz")
+    check50.run("python3 foo.py").stdin("bar\nbaz").stdout("hello bar").stdout("hello baz").exit()
 
 @check50.check()
 def prints_hello_name_chaining():
     """prints hello name (chaining)"""
-    check50.run("python3 foo.py").stdin("bar", prompt=False).stdout("hello bar").stdin("baz", prompt=False).stdout("hello baz")
+    check50.run("python3 foo.py").stdin("bar", prompt=False).stdout("hello bar").stdin("baz", prompt=False).stdout("hello baz").exit()
 
 @check50.check()
 def prints_hello_name_chaining_order():
     """prints hello name (chaining) (order)"""
-    check50.run("python3 foo.py").stdin("bar", prompt=False).stdin("baz", prompt=False).stdout("hello bar").stdout("hello baz")
+    check50.run("python3 foo.py").stdin("bar", prompt=False).stdin("baz", prompt=False).stdout("hello bar").stdout("hello baz").exit()

--- a/tests/checks/stdin_prompt_py/check.py
+++ b/tests/checks/stdin_prompt_py/check.py
@@ -3,4 +3,4 @@ import check50
 @check50.check()
 def prints_hello_name():
     """prints hello name"""
-    check50.run("python3 foo.py").stdin("bar", prompt=True).stdout("hello bar")
+    check50.run("python3 foo.py").stdin("bar", prompt=True).stdout("hello bar").exit()

--- a/tests/checks/stdin_py/check.py
+++ b/tests/checks/stdin_py/check.py
@@ -8,4 +8,4 @@ def exists():
 @check50.check(exists)
 def prints_hello_name():
     """prints hello name"""
-    check50.run("python3 foo.py").stdin("bar", prompt=False).stdout("hello bar")
+    check50.run("python3 foo.py").stdin("bar", prompt=False).stdout("hello bar").exit()

--- a/tests/checks/stdout_py/check.py
+++ b/tests/checks/stdout_py/check.py
@@ -8,4 +8,4 @@ def exists():
 @check50.check(exists)
 def prints_hello():
     """prints hello"""
-    check50.run("python3 foo.py").stdout("hello", show_timeout=True, timeout=1)
+    check50.run("python3 foo.py").stdout("hello", show_timeout=True, timeout=1).exit()

--- a/tests/flask_tests.py
+++ b/tests/flask_tests.py
@@ -18,10 +18,12 @@ class Base(unittest.TestCase):
         if not FLASK_INSTALLED:
             raise unittest.SkipTest("flask not installed")
 
+        self.current_working_directory = os.getcwd()
         self.working_directory = tempfile.TemporaryDirectory()
         os.chdir(self.working_directory.name)
 
     def tearDown(self):
+        os.chdir(self.current_working_directory)
         self.working_directory.cleanup()
 
 class TestApp(Base):

--- a/tests/py_tests.py
+++ b/tests/py_tests.py
@@ -8,6 +8,7 @@ import check50.internal
 
 class Base(unittest.TestCase):
     def setUp(self):
+        self.current_working_directory = os.getcwd()
         self.working_directory = tempfile.TemporaryDirectory()
         os.chdir(self.working_directory.name)
 
@@ -19,6 +20,7 @@ class Base(unittest.TestCase):
             f.write(source)
 
     def tearDown(self):
+        os.chdir(self.current_working_directory)
         self.working_directory.cleanup()
 
     def runpy(self):

--- a/tests/runner_tests.py
+++ b/tests/runner_tests.py
@@ -26,6 +26,7 @@ else:
 
 class TestMultiprocessingStartMethods(unittest.TestCase):
     def setUp(self):
+        self.current_working_directory = os.getcwd()
         self.working_directory = tempfile.TemporaryDirectory()
         os.chdir(self.working_directory.name)
 
@@ -37,6 +38,7 @@ class TestMultiprocessingStartMethods(unittest.TestCase):
         self._get_start_method = multiprocessing.get_start_method()
 
     def tearDown(self):
+        os.chdir(self.current_working_directory)
         self.working_directory.cleanup()
         multiprocessing.get_start_method = self._get_start_method
 

--- a/tests/simple_tests.py
+++ b/tests/simple_tests.py
@@ -11,10 +11,12 @@ class Base(unittest.TestCase):
     config_file = ".check50.yaml"
 
     def setUp(self):
+        self.current_working_directory = os.getcwd()
         self.working_directory = tempfile.TemporaryDirectory()
         os.chdir(self.working_directory.name)
 
     def tearDown(self):
+        os.chdir(self.current_working_directory)
         self.working_directory.cleanup()
 
     def write(self, source):


### PR DESCRIPTION
Refer to my PR cs50/lib50#79 for more context.

Summary:
1. Use `pexpect.PopenSpawn` instead of `pexpect.spawn`, for both `check50` and testsuite.
2. Use `threading.Timer` for raising timeouts in checks.
3. Add additional `exit()` when compiling checks.
    - This ensures that the check subprocesses run until their cleanup.
    - Existing pre-compiled checks are also modified.
4. Add `check50.run.isalive()` for checking subprocess status.
5. Add quoting for command line arguments.
6. Kill check subprocesses when timeout or EOF is raised.
7. Wait until the compiler's process exits, with a timeout of 30 seconds.