### PR TITLE
check50 will now warn users who try to import the library in a Python interactive mode

### DIFF
--- a/check50/__init__.py
+++ b/check50/__init__.py
@@ -27,7 +27,7 @@ _setup_translation()
 import sys
 if hasattr(sys, 'ps1') or sys.flags.interactive:
     import warnings
-    warnings.warn(_("check50 is not intended for use in interactive mode."
+    warnings.warn(_("check50 is not intended for use in interactive mode. "
                     "Some behavior may not function as expected."))
 
 from ._api import (

--- a/check50/__init__.py
+++ b/check50/__init__.py
@@ -17,6 +17,8 @@ def _setup_translation():
         "check50", str(files("check50").joinpath("locale")), fallback=True)
     _translation.install()
 
+
+
 # Encapsulated inside a function so their local variables/imports aren't seen by autocompleters
 _set_version()
 _setup_translation()

--- a/check50/__init__.py
+++ b/check50/__init__.py
@@ -17,11 +17,18 @@ def _setup_translation():
         "check50", str(files("check50").joinpath("locale")), fallback=True)
     _translation.install()
 
-
-
 # Encapsulated inside a function so their local variables/imports aren't seen by autocompleters
 _set_version()
 _setup_translation()
+
+# Discourage use of check50 in the interactive mode, due to a naming conflict of
+# the `_` variable. check50 uses it for translations, but Python stores the
+# result of the last expression in a variable called `_`.
+import sys
+if hasattr(sys, 'ps1') or sys.flags.interactive:
+    import warnings
+    warnings.warn(_("check50 is not intended for use in interactive mode."
+                    "Some behavior may not function as expected."))
 
 from ._api import (
     import_checks,


### PR DESCRIPTION
#185 has this quote:
> For internationalization, we use python's `gettext` module which adds a function called `_` to the global namespace. Then any time you want a string to be translated based on the locale, you just call `_` on it. This is why you see `_("expected {}, not {}")` in the traceback. However, when the python interpreter runs in interactive mode, it defines a variable called `_` in the global namespace which is equal to the last evaluated expression. 
> [...]
> Essentially, the interpreter overwrites the value of `_` set by `gettext` (i.e. the translation function) with whatever the value of the last expression you evaluated was (in your case the previous check50.Mismatch). So if you type any expression at all after you `import check50`, any of the functions in `check50` that create internationalized output (i.e. most of them) will fail with a similar error.

Since `check50` is practically never used in interactive mode (and wasn't primarily intended to), importing `check50` into interactive mode will now raise a warning.
<img width="726" height="98" alt="image" src="https://github.com/user-attachments/assets/6db58489-f4cf-4241-ab2f-c53fe2566fce" />
