### PR TITLE
Add authentication method flags

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -259,6 +259,20 @@ def process_args(args):
     if args.ansi_log and "ansi" not in seen_output:
         LOGGER.warning(_("--ansi-log has no effect when ansi is not among the output formats"))
 
+    if args.https or args.ssh:
+        if args.offline:
+            LOGGER.warning(_("Using either --https and --ssh will have no effect when running offline"))
+            args.auth_method = None
+        elif args.https and args.ssh:
+            LOGGER.warning(_("--https and --ssh have no effect when used together"))
+            args.auth_method = None
+        elif args.https:
+            args.auth_method = "https"
+        else:
+            args.auth_method = "ssh"
+    else:
+        args.auth_method = None
+
 
 class LoggerWriter:
     def __init__(self, logger, level):
@@ -334,6 +348,18 @@ def main():
     parser.add_argument("--no-install-dependencies",
                         action="store_true",
                         help=_("do not install dependencies (only works with --local)"))
+    parser.add_argument("--assertion-rewrite",
+                        action="store",
+                        nargs="?",
+                        const="enabled",
+                        choices=["true", "enabled", "1", "on", "false", "disabled", "0", "off"],
+                        help=_("enable or disable assertion rewriting; overrides ENABLE_CHECK50_ASSERT flag in the checks file"))
+    parser.add_argument("--https",
+                        action="store_true",
+                        help=_("force authentication via HTTPS"))
+    parser.add_argument("--ssh",
+                        action="store_true",
+                        help=_("force authentication via SSH"))
     parser.add_argument("-V", "--version",
                         action="version",
                         version=f"%(prog)s {__version__}")
@@ -355,7 +381,7 @@ def main():
 
     # If remote, push files to GitHub and await results
     if not args.local:
-        commit_hash = lib50.push("check50", internal.slug, internal.CONFIG_LOADER, data={"check50": True})[1]
+        commit_hash = lib50.push("check50", internal.slug, internal.CONFIG_LOADER, data={"check50": True}, auth_method=args.auth_method)[1]
         with lib50.ProgressBar("Waiting for results") if "ansi" in args.output else nullcontext():
             tag_hash, results = await_results(commit_hash, internal.slug)
 
@@ -392,7 +418,13 @@ def main():
             original_checks_file = (internal.check_dir / config["checks"]).resolve()
 
             # If the user has enabled the rewrite feature
-            if assertions.rewrite_enabled(str(original_checks_file)):
+            assertion_rewrite_enabled = False
+            if args.assertion_rewrite is not None:
+                assertion_rewrite_enabled = args.assertion_rewrite.lower() in ("true", "1", "enabled", "on")
+            else:
+                assertion_rewrite_enabled = assertions.rewrite_enabled(str(original_checks_file))
+
+            if assertion_rewrite_enabled:
                 # Create a temporary copy of the checks file
                 with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as tmp:
                     checks_file = Path(tmp.name)

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -385,11 +385,16 @@ def main():
         try:
             commit_hash = lib50.push("check50", internal.slug, internal.CONFIG_LOADER, data={"check50": True}, auth_method=args.auth_method)[1]
         except lib50.ConnectionError:
-            LOGGER.debug(traceback.format_exc()) # log the traceback
-            raise _exceptions.Error(_(
-                "check50 failed to authenticate your Github account. Try running check50 again with --https or --ssh, "
-                "or try restarting your codespace. If the problem persists, please email us at sysadmins@cs50.harvard.edu."
-            ))
+            LOGGER.debug(traceback.format_exc()
+            if  not os.environ.get("CODESPACES"):
+                raise _exceptions.Error(_(
+                    "check50 failed to authenticate your Github account. Please make sure you are connected to the internet and try again."
+                ))
+        except Exception as e:
+            LOGGER.debug(traceback.format_exc())
+            raise _exceptions.Error(_("Sorry, something's wrong, please try again.\n"
+                                     "If the problem persists, please visit our status page https://cs50.statuspage.io for more information.")) from e
+
         with lib50.ProgressBar("Waiting for results") if "ansi" in args.output else nullcontext():
             tag_hash, results = await_results(commit_hash, internal.slug)
 

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -385,8 +385,8 @@ def main():
         try:
             commit_hash = lib50.push("check50", internal.slug, internal.CONFIG_LOADER, data={"check50": True}, auth_method=args.auth_method)[1]
         except lib50.ConnectionError:
-            LOGGER.debug(traceback.format_exc()
-            if  not os.environ.get("CODESPACES"):
+            LOGGER.debug(traceback.format_exc())
+            if not os.environ.get("CODESPACES"):
                 raise _exceptions.Error(_(
                     "check50 failed to authenticate your Github account. Please make sure you are connected to the internet and try again."
                 ))

--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import traceback
 
 import attr
 import lib50
@@ -381,7 +382,14 @@ def main():
 
     # If remote, push files to GitHub and await results
     if not args.local:
-        commit_hash = lib50.push("check50", internal.slug, internal.CONFIG_LOADER, data={"check50": True}, auth_method=args.auth_method)[1]
+        try:
+            commit_hash = lib50.push("check50", internal.slug, internal.CONFIG_LOADER, data={"check50": True}, auth_method=args.auth_method)[1]
+        except lib50.ConnectionError:
+            LOGGER.debug(traceback.format_exc()) # log the traceback
+            raise _exceptions.Error(_(
+                "check50 failed to authenticate your Github account. Try running check50 again with --https or --ssh, "
+                "or try restarting your codespace. If the problem persists, please email us at sysadmins@cs50.harvard.edu."
+            ))
         with lib50.ProgressBar("Waiting for results") if "ansi" in args.output else nullcontext():
             tag_hash, results = await_results(commit_hash, internal.slug)
 


### PR DESCRIPTION
Allows user to run
```
check50 cs50/problems/2025/x/finance --ssh
```
or
```
check50 cs50/problems/2025/x/finance --https
```
which will change the `auth_method` argument in `push`, which was added in [PR #94 of lib50](https://github.com/cs50/lib50/pull/94).

If neither are included or both are included, the default behavior will occur (with a warning message appearing in the latter).

Using either one of these will change the progress bar's output as well:
<img width="1168" height="162" alt="image" src="https://github.com/user-attachments/assets/01587cc5-9d50-431e-b7de-9f1ce53a9531" />
<img width="1143" height="139" alt="image" src="https://github.com/user-attachments/assets/480d1986-c8fd-4aa5-a71c-80271130a85d" />
