### PR TITLE
Rm attrs

### DIFF
--- a/check50/__main__.py
+++ b/check50/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import contextlib
+import dataclasses
 import enum
 import gettext
 import importlib
@@ -15,7 +16,6 @@ import sys
 import tempfile
 import time
 
-import attr
 import lib50
 import packaging
 import requests
@@ -449,7 +449,7 @@ def main():
                 check_results = check_runner.run(args.target)
                 results = {
                     "slug": internal.slug,
-                    "results": [attr.asdict(result) for result in check_results],
+                    "results": [dataclasses.asdict(result) for result in check_results],
                     "version": __version__
                 }
 

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -1,6 +1,7 @@
 import collections
 from contextlib import contextmanager
 import concurrent.futures as futures
+import dataclasses
 import functools
 import inspect
 import importlib
@@ -13,8 +14,8 @@ import signal
 import sys
 import tempfile
 import traceback
+import typing
 
-import attr
 import lib50
 
 from . import internal, _exceptions, __version__
@@ -23,16 +24,16 @@ from ._api import log, Failure, _copy, _log, _data
 _check_names = []
 
 
-@attr.s(slots=True)
+@dataclasses.dataclass
 class CheckResult:
     """Record returned by each check"""
-    name = attr.ib()
-    description = attr.ib()
-    passed = attr.ib(default=None)
-    log = attr.ib(default=attr.Factory(list))
-    cause = attr.ib(default=None)
-    data = attr.ib(default=attr.Factory(dict))
-    dependency = attr.ib(default=None)
+    name: str
+    description: str
+    passed: typing.Optional[bool] = None
+    log: typing.List[str] = dataclasses.field(default_factory=list)
+    cause: typing.Optional[typing.Dict] = None
+    data: typing.Dict = dataclasses.field(default_factory=dict)
+    dependency: typing.Optional[str] = None
 
     @classmethod
     def from_check(cls, check, *args, **kwargs):
@@ -48,8 +49,7 @@ class CheckResult:
     def from_dict(cls, d):
         """Create a CheckResult given a dict. Dict must contain at least the fields in the CheckResult.
         Throws a KeyError if not."""
-        return cls(**{field.name: d[field.name] for field in attr.fields(cls)})
-
+        return cls(**{field.name: d[field.name] for field in dataclasses.fields(cls)})
 
 
 class Timeout(Failure):

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -14,7 +14,6 @@ import signal
 import sys
 import tempfile
 import traceback
-import typing
 
 import lib50
 
@@ -24,16 +23,16 @@ from ._api import log, Failure, _copy, _log, _data
 _check_names = []
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class CheckResult:
     """Record returned by each check"""
     name: str
     description: str
-    passed: typing.Optional[bool] = None
-    log: typing.List[str] = dataclasses.field(default_factory=list)
-    cause: typing.Optional[typing.Dict] = None
-    data: typing.Dict = dataclasses.field(default_factory=dict)
-    dependency: typing.Optional[str] = None
+    passed: bool | None = None
+    log: list[str] = dataclasses.field(default_factory=list)
+    cause: dict | None = None
+    data: dict = dataclasses.field(default_factory=dict)
+    dependency: str | None = None
 
     @classmethod
     def from_check(cls, check, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     keywords=["check", "check50"],
     name="check50",
     packages=["check50", "check50.renderer", "check50.assertions"],
-    python_requires=">= 3.8",
+    python_requires=">= 3.10",
     entry_points={
         "console_scripts": ["check50=check50.__main__:main"]
     },

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     message_extractors = {
         'check50': [('**.py', 'python', None),],
     },
-    install_requires=["attrs>=18", "beautifulsoup4>=0", "lib50>=3,<4", "packaging", "pexpect>=4.6", "pyyaml>6,<7", "requests>=2.19", "setuptools", "termcolor>=1.1", "jinja2>=2.10"],
+    install_requires=["beautifulsoup4>=0", "lib50>=3,<4", "packaging", "pexpect>=4.6", "pyyaml>6,<7", "requests>=2.19", "setuptools", "termcolor>=1.1", "jinja2>=2.10"],
     extras_require = {
         "develop": ["sphinx", "sphinx-autobuild", "sphinx_rtd_theme"]
     },


### PR DESCRIPTION
Per @cmlsharp's comment in https://github.com/cs50/check50/pull/368, Python 3.7 brought with it dataclasses that can directly replace `attrs`. This pr replaces the only uses of `attrs` in `check50` with dataclasses and removes `attrs` as a dependency. 

Opted to use python 3.10 as the 4.0.0-dev branch is already using features from Python 3.10. Such as `match`, and   `importlib.resources.files` that was added in Python 3.9.

Used python 3.10 syntax for type hints (notably the use of `|`, and `list` instead of `typing.List`).
Set `slots=True` which is only supported from 3.10 onwards.