### PR TITLE
Make `_raw` output quotes only when the input is actually a string

### DIFF
--- a/check50/_api.py
+++ b/check50/_api.py
@@ -425,12 +425,10 @@ class Missing(Failure):
     """
 
     def __init__(self, missing_item, collection, help=None):
-        if isinstance(collection, list):
-            collection = _process_list(collection, _raw)
-
+        missing_item, collection = _raw(missing_item), _raw(collection)
         truncated_collection = _truncate(collection, missing_item)
 
-        super().__init__(rationale=_("Did not find {} in {}").format(_raw(missing_item), _raw(truncated_collection)), help=help)
+        super().__init__(rationale=_("Did not find {} in {}").format(missing_item, truncated_collection), help=help)
 
         if missing_item == EOF:
             missing_item = "EOF"
@@ -461,16 +459,17 @@ class Mismatch(Failure):
     """
 
     def __init__(self, expected, actual, help=None):
+        expected, actual = _raw(expected), _raw(actual)
         expected, actual = _truncate(expected, actual), _truncate(actual, expected)
 
         rationale = _("expected: {}\n    actual:   {}").format(
-            _raw(expected),
-            _raw(actual)
+            expected,
+            actual
         )
 
         super().__init__(rationale=rationale, help=help)
 
-        self.payload.update({"expected": _raw(expected), "actual": _raw(actual)})
+        self.payload.update({"expected": expected, "actual": actual})
 
 
 def hidden(failure_rationale):
@@ -609,9 +608,10 @@ def _raw(s):
         return "EOF"
     elif s == TIMEOUT:
         return "TIMEOUT"
-
-    s = f'"{repr(str(s))[1:-1]}"'
-    return s
+    elif isinstance(s, list):
+        return "[{}]".format(", ".join(_raw(item) for item in s))
+    
+    return repr(s)
 
 
 def _copy(src, dst):

--- a/tests/check50_tests.py
+++ b/tests/check50_tests.py
@@ -99,8 +99,8 @@ class TestStdoutPy(Base):
         process.expect_exact("foo.py exists")
         process.expect_exact(":(")
         process.expect_exact("prints hello")
-        process.expect_exact("expected: \"hello\"")
-        process.expect_exact("actual:   \"\"")
+        process.expect_exact("expected: 'hello'")
+        process.expect_exact("actual:   ''")
         process.close(force=True)
 
 
@@ -146,8 +146,8 @@ class TestStdinPy(Base):
         process.expect_exact("foo.py exists")
         process.expect_exact(":(")
         process.expect_exact("prints hello name")
-        process.expect_exact("expected: \"hello bar\"")
-        process.expect_exact("actual:   \"\"")
+        process.expect_exact("expected: 'hello bar'")
+        process.expect_exact("actual:   ''")
         process.close(force=True)
 
     def test_with_correct_file(self):


### PR DESCRIPTION
Closes #377.
Depends on changes made in #394.

Made `Mismatch` and `Missing` have their inputs be passed to `_raw` before `_truncate`.

Removed double quotes in output of `_raw`.

