### PR TITLE
fix: support forkserver multiprocessing start method (Python 3.14+)

### DIFF
--- a/check50/runner.py
+++ b/check50/runner.py
@@ -347,7 +347,7 @@ class run_check:
         """
 
         # Attributes only need to be passed explicitly to child processes when using spawn
-        if multiprocessing.get_start_method() != "spawn":
+        if multiprocessing.get_start_method() == "fork":
            return
 
         self._attribute_values = [eval(name) for name in self.CROSS_PROCESS_ATTRIBUTES]


### PR DESCRIPTION
Python 3.14 changed the default multiprocessing start method on Linux from "fork" to "forkserver". The _store_attributes guard only passed cross-process state for "spawn", leaving "forkserver" children with None for run_root_dir and other attributes.

Invert the condition to only skip for "fork", which is the only method that inherits full parent memory.