### PR TITLE
feat add performance metric with performance50 for time and memory tracking

### DIFF
--- a/check50/renderer/_renderers.py
+++ b/check50/renderer/_renderers.py
@@ -29,6 +29,14 @@ def to_ansi(slug, results, version, _log=False):
     for result in results:
         if result["passed"]:
             lines.append(termcolor.colored(f":) {result['description']}", "green"))
+            
+            msg = f":) {result['description']}"
+            
+            if result.get("data") and "performance50" in result["data"]:
+                perf = result["data"]["performance50"]
+                msg += f" ({perf['time_ms']}ms) ({perf['memory_kb']}KB)"
+
+            lines.append(termcolor.colored(msg, "green"))
         elif result["passed"] is None:
             lines.append(termcolor.colored(f":| {result['description']}", "yellow"))
             lines.append(termcolor.colored(f"    {result['cause'].get('rationale') or _('check skipped')}", "yellow"))

--- a/check50/renderer/templates/results.html
+++ b/check50/renderer/templates/results.html
@@ -19,6 +19,12 @@
                   {% else %}
                       <h3 style="color:orange">:| {{ check.description }}</h3>
                   {% endif %}
+                  {% if check.data and check.data.performance50 %}
+                      <div style="margin-bottom: 10px; margin-left: 25px;">
+                          <span class="label label-info">Time: {{ check.data.performance50.time_ms }} ms</span>
+                          <span class="label label-default">Memory: {{ check.data.performance50.memory_kb }} KB</span>
+                      </div>
+                  {% endif %}
 
                   {% if check.cause or check.log %}
                       <div class="well well-sm">

--- a/check50/runner.py
+++ b/check50/runner.py
@@ -13,12 +13,14 @@ import signal
 import sys
 import tempfile
 import traceback
+import time
+import resource
 
 import attr
 import lib50
 
 from . import internal, _exceptions, __version__
-from ._api import log, Failure, _copy, _log, _data
+from ._api import log, Failure, _copy, _log, _data,data
 
 _check_names = []
 
@@ -143,7 +145,14 @@ def check(dependency=None, timeout=60, max_log_lines=100):
                 # Run registered functions before/after running check and set timeout
                 with internal.register, _timeout(seconds=timeout):
                     args = (dependency_state,) if inspect.getfullargspec(check).args else ()
+                    
+                    # start the time counter for performance timing
+                    start_time = time.perf_counter()
                     state = check(*args)
+                    elapsed_ms -= (time.perf_counter() - start_time) * 1000
+                    # total ram usage for this check
+                    memory_usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+                    data(performance50={"time_ms": round(elapsed_ms, 2), "memory_kb": memory_usage})
             except Failure as e:
                 result.passed = False
                 result.cause = e.payload


### PR DESCRIPTION
Solve the #301 by adding `performance50` metrics to result data.

- System level profiling using `time.perf_counter()` from `import time`
- memory usage profiling using `resource.getrusage(resource.RUSAGE_SELF).ru_maxrss` from `import resources` which returns the memory size used by a child process in UNIX environment.
- Text rendering in terminal and reder.html